### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "readmeFilename": "README.md",
   "cozy-permissions": {
     "Contact": {
-      "description": "Creates and edits your contacts."
+      "description": "Create and edit your contacts."
     },
     "CozyInstance": {
       "description": "Read language setting"


### PR DESCRIPTION
minor edit to have verbs on imperative mode, which is more consistent when displaying description on install or update