### PR TITLE
Cozy Webdav to Cozy Sync, Calendar to Contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cozy Contacts makes your contact management easy. Main features are:
 * Contact tagging
 * Contact notes
 * VCF import
-* CardDAV sync (it requires [Cozy Webdav](https://github.com/mycozycloud/cozy-webdav))
+* CardDAV sync (it requires [Cozy Sync](https://github.com/cozy/cozy-sync))
 
 ## Install
 

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -135,8 +135,8 @@ module.exports =
     Click here to export all your contacts as a vCard file:"""
 
   "sync title"                : "Mobile Synchronization (CardDav)"
-  "sync headline no data"     : "To synchronize your calendar with your devices, you must follow two steps"
-  "sync headline with data"   : "To synchronize your calendar, use the following information:"
+  "sync headline no data"     : "To synchronize your contacts with your devices, you must follow two steps"
+  "sync headline with data"   : "To synchronize your contacts, use the following information:"
   "sync url"                  : "URL:"
   "sync login"                : "Username:"
   "sync password"             : "Password: "


### PR DESCRIPTION
Two little improvement, I changed the link, in Readme from the one pointing to the old Cozy Webdav to the new Cozy Sync and I changed in the help pannel of contacts, the word "calendar" by "contacts", in the explanation about synchronisation.