### PR TITLE
Don't strip whitespace when sorting contacts, fixes #143

### DIFF
--- a/build/client/public/javascripts/app.js
+++ b/build/client/public/javascripts/app.js
@@ -187,8 +187,8 @@ module.exports = ContactCollection = (function(_super) {
 
   ContactCollection.prototype.comparator = function(a, b) {
     var compare, nameA, nameB, out;
-    nameA = a.getDisplayName().replace(/\ /g, '').toLowerCase();
-    nameB = b.getDisplayName().replace(/\ /g, '').toLowerCase();
+    nameA = a.getDisplayName().toLowerCase();
+    nameB = b.getDisplayName().toLowerCase();
     compare = nameA.localeCompare(nameB);
     return out = compare > 0 ? 1 : compare < 0 ? -1 : 0;
   };

--- a/client/app/collections/contact.coffee
+++ b/client/app/collections/contact.coffee
@@ -9,8 +9,8 @@ module.exports = class ContactCollection extends Backbone.Collection
 
     #sort by names
     comparator: (a,b) ->
-        nameA = a.getDisplayName().replace(/\ /g, '').toLowerCase()
-        nameB = b.getDisplayName().replace(/\ /g, '').toLowerCase()
+        nameA = a.getDisplayName().toLowerCase()
+        nameB = b.getDisplayName().toLowerCase()
         compare = nameA.localeCompare nameB
         out = if compare > 0 then 1
         else if compare < 0 then -1


### PR DESCRIPTION
Not stripping whitespace in the full name seems to fix the sorting issues in #143 

I'd also like to write a test for this, but the only existing tests I could find are server side?