### PR TITLE
Fixes in duplicates scenario

### DIFF
--- a/client/app/locales/en.json
+++ b/client/app/locales/en.json
@@ -59,6 +59,7 @@
 
     "duplicates title":                 "Find Duplicates",
     "duplicates actions mergeall":      "merge all",
+    "duplicates empty":                 "No duplicates found",
     "mergerow actions merge":           "merge",
     "mergerow actions dismiss":         "dismiss",
 

--- a/client/app/locales/fr.json
+++ b/client/app/locales/fr.json
@@ -59,6 +59,7 @@
 
     "duplicates title":                 "Doublons",
     "duplicates actions mergeall":      "tout fusionner",
+    "duplicates empty":                 "Aucun doublon détecté",
     "mergerow actions merge":           "fusionner",
     "mergerow actions dismiss":         "abandonner",
 

--- a/client/app/views/contacts/card.coffee
+++ b/client/app/views/contacts/card.coffee
@@ -37,6 +37,7 @@ module.exports = class ContactCardView extends Mn.LayoutView
         formSubmit: '[type=submit]'
         formClear:  'button.clear'
         formInputs: '.group:not([data-cid]) :input:not(button)'
+        avatar:     '.avatar'
 
     regions:
         'avatar': '[role=img]'

--- a/client/app/views/contacts/merge.coffee
+++ b/client/app/views/contacts/merge.coffee
@@ -25,7 +25,7 @@ module.exports = class MergeView extends Mn.ItemView
         'contacts:merge': 'onClose'
 
     events:
-        'click @ui.cancel': 'onClose'
+        'click @ui.cancel': 'onCancel'
 
 
     initialize: ->
@@ -38,6 +38,14 @@ module.exports = class MergeView extends Mn.ItemView
 
     onFormSubmit: ->
         @model.merge()
+        # Close directly here, to give reactivity feeling.
+        @onClose()
+
+
+    onCancel: ->
+        # Trigger merge procedure ended, with 'abort' error.
+        @model.trigger 'contacts:merge', @model, "abort"
+        @onClose()
 
 
     onClose: ->

--- a/client/app/views/contacts/merge.coffee
+++ b/client/app/views/contacts/merge.coffee
@@ -17,9 +17,9 @@ module.exports = class MergeView extends Mn.ItemView
         Form:      {}
 
     ui:
-        submit:   '[type=submit]'
-        cancel:   '.cancel'
-        inputs:   'input'
+        formSubmit: '[type=submit]'
+        formInputs: 'input'
+        cancel: '.cancel'
 
     modelEvents:
         'contacts:merge': 'onClose'

--- a/client/app/views/duplicates.coffee
+++ b/client/app/views/duplicates.coffee
@@ -52,9 +52,6 @@ module.exports = class DuplicatesView extends Mn.CompositeView
         # Block any input during mergeall.
         @$('button,input').attr 'disabled', 'disabled'
 
-        window.setImmediate = window.setImmediate or (callback) ->
-            setTimeout callback, 1
-
         async.eachSeries @toMerge.toArray(), (merge, callback) =>
             # After a Mergerow::merge, a the merge ViewModel always trigger a
             # contacts:merge event:
@@ -62,9 +59,11 @@ module.exports = class DuplicatesView extends Mn.CompositeView
             # * when an error occurs inn merge (error as second arg)
             # * when the user cancel the merge (abort error as second arg).
             @listenTo merge, 'contacts:merge', (model, err) ->
-                setImmediate ->
-                # setTimeout ->
+                # Let the UI breath.
+                # TODO: replace with a cleaner setImmediate call.
+                setTimeout ->
                     callback err
+                , 1
 
             @children.findByModel(merge).merge()
 

--- a/client/app/views/duplicates.coffee
+++ b/client/app/views/duplicates.coffee
@@ -49,7 +49,6 @@ module.exports = class DuplicatesView extends Mn.CompositeView
 
 
     mergeAll: ->
-        console.log 'mergeAll'
         # Block any input during mergeall.
         @$('button,input').attr 'disabled', 'disabled'
 

--- a/client/app/views/mergerow.coffee
+++ b/client/app/views/mergerow.coffee
@@ -25,12 +25,19 @@ module.exports = class MergeRow extends Mn.ItemView
 
 
     serializeData: ->
+        if @model.has 'result'
+            result = new  ContactViewModel { new: false }
+            , { model: @model.get('result')}
+        else
+            result = undefined
+
         return _.extend super,
             candidates: @model.get('candidates').map (contact) ->
                 new ContactViewModel { new: false }, { model: contact}
             selected: @model.get('candidates').map (contact) =>
                 contact in @model.get('toMerge')
             isMergeable: @model.isMergeable()
+            result: result
 
 
     check: (ev) ->

--- a/client/app/views/mergerow.coffee
+++ b/client/app/views/mergerow.coffee
@@ -17,8 +17,6 @@ module.exports = class MergeRow extends Mn.ItemView
 
     modelEvents:
         'change': 'render'
-        'contacts:merge': 'end'
-
 
     events:
         'click @ui.submit': 'merge'
@@ -30,6 +28,9 @@ module.exports = class MergeRow extends Mn.ItemView
         return _.extend super,
             candidates: @model.get('candidates').map (contact) ->
                 new ContactViewModel { new: false }, { model: contact}
+            selected: @model.get('candidates').map (contact) =>
+                contact in @model.get('toMerge')
+            isMergeable: @model.isMergeable()
 
 
     check: (ev) ->
@@ -42,12 +43,6 @@ module.exports = class MergeRow extends Mn.ItemView
 
 
     merge: ->
-        if @model.get('toMerge').length <= 1
-            # cant merge one or 0 contact, pass
-            console.log 'not enought contact to merge.'
-            @end()
-            return
-
         mergeOptions = @model.buildMergeOptions()
         if Object.keys(mergeOptions).length is 0
             # No question to the user, go to merge directly
@@ -56,7 +51,3 @@ module.exports = class MergeRow extends Mn.ItemView
             MergeView = require 'views/contacts/merge'
             app = require 'application'
             app.layout.showChildView 'alerts', new MergeView model: @model
-
-
-    end: ->
-        @trigger 'contacts:group:merge'

--- a/client/app/views/templates/contacts/merge.jade
+++ b/client/app/views/templates/contacts/merge.jade
@@ -10,19 +10,18 @@ block content
               -var option = options[i]
                   li
                       label(for="merge-#{fieldName}-#{i}")
-                        if model[fieldName] == option.index
-                            input(type="radio", name=fieldName,
-                                value=option.index, id="merge-#{fieldName}-#{i}"
-                                , checked)
-                        else
-                            input(type="radio", name=fieldName,
-                                value=option.index, id="merge-#{fieldName}-#{i}")
+                          input(type="radio", name=fieldName,
+                              value=option.index, id="merge-#{fieldName}-#{i}",
+                              checked=(model[fieldName] == option.index))
 
-                        if fieldName == 'avatar'
-                            img.avatar(src=option.value)
-                        else
-                            i
-                            = option.value
+                          if fieldName == 'avatar'
+                              img.avatar(src=option.value)
+                          else
+                              i
+                              if fieldName == 'fullname'
+                                  span!= option.value
+                              else
+                                  = option.value
 
     h1= t('merge title')
 
@@ -32,10 +31,10 @@ block content
           dd
             +radio(model.mergeOptions.avatar, "avatar")
 
-        if model.mergeOptions.fn != null
+        if model.mergeOptions.fullname != null
           dt= t('merge choose name')
           dd
-            +radio(model.mergeOptions.fn, "fn")
+            +radio(model.mergeOptions.fullname, "fullname")
 
         if model.mergeOptions.nickname != null
           dt= t('merge choose nickname')

--- a/client/app/views/templates/duplicates.jade
+++ b/client/app/views/templates/duplicates.jade
@@ -6,7 +6,9 @@ block content
     button(type="submit").ui-mergeall
         .fa.fa-code-fork
         span= t('duplicates actions mergeall')
-          |  (#{size})
+        |  (
+        span.mergeallcount= size
+        | )
 
     ul
 

--- a/client/app/views/templates/mergerow.jade
+++ b/client/app/views/templates/mergerow.jade
@@ -27,7 +27,6 @@ mixin contactrow(contact)
     +formatDatapoints(contactJson.email, 'email')
 
 
-
 if result
     ul(role='list')
         li.ui-contactrow(role='listitem')
@@ -39,7 +38,7 @@ else
         .btn-group
             button.cancel.outline.secondary()
                 span= t('mergerow actions dismiss')
-            button(type="submit")
+            button(type="submit", disabled=!isMergeable)
                 .fa.fa-code-fork
                 span= t('mergerow actions merge')
 
@@ -48,8 +47,10 @@ else
             for contact, index in candidates
                     li(role='listitem')
                         label
-                            input(type='checkbox', name="mergecontact-#{index}",
-                                checked="checked", value="#{index}")
+                            input(type='checkbox',
+                                name="mergecontact-#{index}",
+                                value="#{index}",
+                                checked=selected[index])
+
                             .ui-contactrow
                                 +contactrow(contact)
-


### PR DESCRIPTION
* rewrite mergeAll algorithm
* improve merge speed
* avoid successive calls to merge on the same mergegroup
* improve mergeall counter (realtime update)
* improve fullname display in merge dialog
* close merge dialog on click (don't wait for true merging), improving reactivity feeling
* add "no duplicates" message
