### PR TITLE
Errors handling

### DIFF
--- a/client/app/initialize.coffee
+++ b/client/app/initialize.coffee
@@ -5,7 +5,33 @@ Sets the browser environment to prepare it to launch the app, and then require
 the application.
 ###
 
-application = require './application'
+
+###
+Logging
+
+Send client side errors to server.
+###
+window.onerror = (msg, url, line, col, error) ->
+    console.error msg, url, line, col, error, error?.stack
+    exception = error?.toString() or msg
+    if exception isnt window.lastError
+        data =
+            data:
+                type: 'error'
+                error:
+                    msg: msg
+                    name: error?.name
+                    full: exception
+                    stack: error?.stack
+                url: url
+                line: line
+                col: col
+                href: window.location.href
+        xhr = new XMLHttpRequest()
+        xhr.open 'POST', 'log', true
+        xhr.setRequestHeader "Content-Type", "application/json;charset=UTF-8"
+        xhr.send JSON.stringify(data)
+        window.lastError = exception
 
 
 ###
@@ -13,6 +39,8 @@ Starts
 
 Trigger locale initilization and starts application singleton.
 ###
+application = require './application'
+
 $ ->
     Mn.Behaviors.behaviorsLookup = require 'lib/behaviors'
     # Temporary use a global variable to store the `t` helpers, waiting for

--- a/client/app/models/contact.coffee
+++ b/client/app/models/contact.coffee
@@ -1,3 +1,10 @@
+class Datapoint extends Backbone.Model
+    defaults:
+        name: 'other'
+        type: 'other'
+        value: ''
+
+
 module.exports = class Contact extends Backbone.Model
 
     urlRoot: 'contacts'
@@ -16,9 +23,10 @@ module.exports = class Contact extends Backbone.Model
                 type:  'main'
                 value: url
 
-        datapoints = @attributes.datapoints or new Backbone.Collection()
+        # Ensure Datapoints consistency
+        datapoints = @attributes.datapoints or
+            new Backbone.Collection attrs.datapoints or [], model: Datapoint
         datapoints.comparator = 'name'
-        datapoints.set attrs.datapoints if attrs.datapoints
         attrs.datapoints = datapoints
 
         attrs.tags = _.invoke attrs.tags, 'toLowerCase'


### PR DESCRIPTION
This PR re-enable the error-reporter for logging. It also fixes a bug that prevent app to load if a datappoint is malformed (missing `type`).