### PR TITLE
Display a loader before saving a contact

### DIFF
--- a/client/app/lib/behaviors/form.coffee
+++ b/client/app/lib/behaviors/form.coffee
@@ -50,3 +50,4 @@ module.exports = class Form extends Mn.Behavior
     deleteField: (event) ->
         cid = @$(event.currentTarget).parents('[data-cid]').data 'cid'
         @view.triggerMethod 'form:field:delete', cid, event
+

--- a/client/app/lib/behaviors/navigator.coffee
+++ b/client/app/lib/behaviors/navigator.coffee
@@ -22,3 +22,4 @@ module.exports = class Navigator extends Mn.Behavior
                 'confirm:close': -> Mn.unbindEntityEvents @, @view
         else
             callback()
+

--- a/client/app/views/contacts/card.coffee
+++ b/client/app/views/contacts/card.coffee
@@ -50,6 +50,9 @@ module.exports = class ContactCardView extends Mn.LayoutView
     triggers:
         'click @ui.btnExport': 'export'
 
+    events:
+        'click @ui.formSubmit': 'showSaving'
+
     modelEvents:
         'change:edit':     'render'
         'save':            'onSave'
@@ -95,6 +98,7 @@ module.exports = class ContactCardView extends Mn.LayoutView
         return unless @model.get 'new'
         app  = require 'application'
         dest = "contacts/#{@model.get 'id'}"
+        @hideSaving()
         app.router.navigate dest, trigger: true
 
 
@@ -106,4 +110,16 @@ module.exports = class ContactCardView extends Mn.LayoutView
         inputs = @$('.data.edit').find('input:not([type="hidden"]), textarea')
         if document.activeElement.tagName.toLowerCase() isnt 'textarea'
             inputs.eq(inputs.index(document.activeElement) + 1).trigger 'focus'
+
+
+    # Display saving by changing aria state of save button to true (save button
+    # is called form submit).
+    showSaving: ->
+        @ui.formSubmit.attr 'aria-busy', true
+
+
+    # Display saving by changing aria state of save button to false (save
+    # button is called form submit).
+    hideSaving: ->
+        @ui.formSubmit.attr 'aria-busy', false
 

--- a/client/app/views/models/contact.coffee
+++ b/client/app/views/models/contact.coffee
@@ -25,7 +25,8 @@ module.exports = class ContactViewModel extends Backbone.ViewModel
         'tags:update':    'updateTags'
         'tags:add':       'addNewTag'
         'form:field:add': 'onAddField'
-        'form:submit':    -> @save()
+        'form:submit':    ->
+            @save()
         'export':         'downloadAsVCF'
         'delete':         -> @destroy()
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
-{ "name": "cozy-contacts",
+{ 
+  "name": "cozy-contacts",
   "version": "2.1.3",
   "author": "Cozy Cloud <contact@cozycloud.cc> (http://cozycloud.cc)",
   "licenses": [


### PR DESCRIPTION
No feedback was given to the user when he clicked on "save" after a contact creation.