### PR TITLE
Make mass deletion faster

### DIFF
--- a/client/app/lib/request.coffee
+++ b/client/app/lib/request.coffee
@@ -1,0 +1,33 @@
+# Make ajax request more simpler to send.
+module.exports = request =
+    send: (type, url, data, callback) ->
+        $.ajax
+            type: type
+            url: url
+            data: if data? then JSON.stringify data else null
+            contentType: "application/json"
+            dataType: "json"
+            success: (data) ->
+                callback null, data if callback?
+            error: (data) ->
+                if data? and data.msg? and callback?
+                    callback new Error data.msg
+                else if callback?
+                    callback new Error "Server error occured"
+
+    # Sends a get request.
+    get: (url, callback) ->
+        request.send "GET", url, null, callback
+
+    # Sends a post request with data as body.
+    post: (url, data, callback) ->
+        request.send "POST", url, data, callback
+
+    # Sends a put request with data as body.
+    put: (url, data, callback) ->
+        request.send "PUT", url, data, callback
+
+    # Sends a delete request.
+    del: (url, callback) ->
+        exports.request "DELETE", url, null, callback
+

--- a/client/app/lib/views/confirm.coffee
+++ b/client/app/lib/views/confirm.coffee
@@ -8,7 +8,6 @@ module.exports = class ConfirmDialogView extends Mn.ItemView
         role: 'alertdialog'
         'aria-busy': false
 
-
     ui:
         btn_ok:     'button.ok'
         btn_cancel: 'button.cancel'
@@ -16,7 +15,7 @@ module.exports = class ConfirmDialogView extends Mn.ItemView
     triggers:
         'click @ui.btn_ok':     'confirm:true'
         'click @ui.btn_cancel': 'confirm:false'
-        'click button':         'confirm:close'
+        'click @ui.btn_cancel': 'confirm:close'
 
 
     onDomRefresh: ->
@@ -28,3 +27,12 @@ module.exports = class ConfirmDialogView extends Mn.ItemView
     onConfirmClose: ->
         {layout} = require 'application'
         layout.alerts.empty()
+
+
+    showLoading: ->
+        @ui.btn_ok.attr 'aria-busy', true
+
+
+    hideLoading: ->
+        @ui.btn_ok.attr 'aria-busy', false
+

--- a/client/app/views/models/app.coffee
+++ b/client/app/views/models/app.coffee
@@ -1,5 +1,6 @@
 MergeView = require 'views/contacts/merge'
 MergeModel = require 'views/models/merge'
+request = require 'lib/request'
 
 app = undefined
 
@@ -52,16 +53,23 @@ module.exports = class AppViewModel extends Backbone.ViewModel
         @set selected: []
 
 
+    # Delete currently selected conctacts.
+    # It fires a bulk:delete:done event when everything is done. That way
+    # other components can be informed.
     bulkDelete: ->
         selected = @attributes.selected
+        request.post '/contacts/bulk-delete', selected, (err, res) =>
 
-        success = (model) => @unselect model.id
+            if err
+                console.log err
+                alert t 'contacts delete bulk error'
 
-        app.contacts.chain()
-            .filter (contact) ->
-                contact.id in selected
-            .invoke 'destroy', {wait:true, success: success}
-            .value()
+            else
+                app.contacts.disableSort()
+                app.contacts.remove selected
+                @set selected: []
+                app.contacts.enableSort()
+                @trigger 'bulk:delete:done'
 
 
     # TODO: probably need to be revamped when doing it for the whole merge
@@ -122,3 +130,4 @@ module.exports = class AppViewModel extends Backbone.ViewModel
                     @set 'errors', upload: 'error upload wrong filetype'
         else
             @set 'errors', upload: 'error upload wrong filetype'
+

--- a/client/app/views/models/app.coffee
+++ b/client/app/views/models/app.coffee
@@ -58,6 +58,7 @@ module.exports = class AppViewModel extends Backbone.ViewModel
     # other components can be informed.
     bulkDelete: ->
         selected = @attributes.selected
+        app.contacts.contactListener.disable()
         request.post '/contacts/bulk-delete', selected, (err, res) =>
 
             if err
@@ -69,6 +70,7 @@ module.exports = class AppViewModel extends Backbone.ViewModel
                 app.contacts.remove selected
                 @set selected: []
                 app.contacts.enableSort()
+                setTimeout app.contacts.contactListener.enable, 1500
                 @trigger 'bulk:delete:done'
 
 

--- a/client/app/views/models/contact.coffee
+++ b/client/app/views/models/contact.coffee
@@ -166,7 +166,7 @@ module.exports = class ContactViewModel extends Backbone.ViewModel
             wait: true
             success: =>
                 tags = @model.get('tags').concat tag
-                @model.save tags: tags
+                @updateTags tags
 
 
     onSave: ->

--- a/client/app/views/tools/context_actions.coffee
+++ b/client/app/views/tools/context_actions.coffee
@@ -6,7 +6,9 @@ module.exports = class DefaultActionsView extends Mn.ItemView
 
 
     behaviors: ->
-        Confirm: triggers: 'click @ui.delete': @_deleteModalCfg
+        Confirm:
+            triggers:
+                'click @ui.delete': @_deleteModalCfg
 
 
     ui:
@@ -23,6 +25,7 @@ module.exports = class DefaultActionsView extends Mn.ItemView
         'click @ui.export':   'bulk:export'
         'click @ui.merge':    'bulk:merge'
 
+
     modelEvents:
         'change:selected': (nil, selected) -> @render() if selected.length
 
@@ -31,12 +34,17 @@ module.exports = class DefaultActionsView extends Mn.ItemView
         Mn.bindEntityEvents @model, @, @model.viewEvents
 
 
+    # Build configuration required to display a proper modal. This modal will
+    # ask the user for a confirmation of deletion.
+    # To display this modal, we rely on the Marionnette behavior called
+    # Confirm.
     _deleteModalCfg: =>
         opts = smart_count: @model.get('selected').length
-        return cfg =
+        return behaviorConfig =
             event:      'bulk:delete'
             title:      t 'bulk confirm delete title', opts
             message:    t 'bulk confirm delete message', opts
             btn_ok:     t 'bulk confirm delete ok'
             btn_cancel: t 'bulk confirm delete cancel'
+            end_event:  'bulk:delete:done'
 

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -24,6 +24,9 @@ module.exports =
         get: contact.list
         post: contact.create
 
+    'contacts/bulk-delete':
+        post: contact.bulkDelete
+
     'contacts/:contactid':
         get: contact.read
         put: contact.update

--- a/test/contact.coffee
+++ b/test/contact.coffee
@@ -156,7 +156,6 @@ describe 'Contacts', ->
 
 
     describe 'Delete - DELETE /contacts/:id', ->
-
         it 'should allow requests', (done) ->
             @client.del "contacts/#{_global.id}", done
 
@@ -168,3 +167,28 @@ describe 'Contacts', ->
 
         it 'then i get an error', ->
             expect(@response.statusCode).to.equal 404
+
+
+    describe 'Delete - POST /contacts/bulk-delete', ->
+
+        ids = []
+
+        before (done) ->
+            @client.get 'contacts', =>
+                ids.push @body[0].id
+                ids.push @body[1].id
+                done()
+
+        it 'should allow requests', (done) ->
+            @client.post "contacts/bulk-delete", ids, done
+
+        it 'should reply with 204 status', ->
+            expect(@response.statusCode).to.equal 200
+
+        it 'when I GET all contacts', (done) ->
+            @client.get "contacts", =>
+                done()
+
+        it 'then deleted contacts are no more there', ->
+            expect(@body.length).to.equal 0
+


### PR DESCRIPTION
This PR simplifies the behavior of mass deletion. It's because prior to that PR, the user didn't have a good user experience while deleting his contacts. It froze the browser. We still have performance issues in that PR but they are much less annoying.

Extras : 

* Fix contacts creation with new tags (datapoints are now saved)
* Make remote operation less heavy when they occur.
* Make import less slow, it creates contacts one by one and do not handle their addition (it just refreshes the whole at the end of the process.
