### PR TITLE
Make merge experience faster

### DIFF
--- a/client/app/collections/duplicates.coffee
+++ b/client/app/collections/duplicates.coffee
@@ -10,7 +10,7 @@ module.exports = class Duplicates extends Backbone.Collection
     # Local collection
     url: null
 
-    # Initialize the collection with duplicates fund in the sepcified contacts
+    # Initialize the collection with duplicates found in the specified contacts
     # collection.
     initialize: ([], options) ->
         collection = options.collection
@@ -23,3 +23,4 @@ module.exports = class Duplicates extends Backbone.Collection
             # Create a merge ViewModel and add it to the collection,
             # initialize with the specified candidates ContactsViewModels.
             @add { candidates }
+

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -217,3 +217,4 @@ module.exports = class AppLayout extends Mn.LayoutView
             @ui.counter
             .text t 'error search too short'
             .addClass 'important'
+

--- a/client/app/views/duplicates/index.coffee
+++ b/client/app/views/duplicates/index.coffee
@@ -39,6 +39,7 @@ module.exports = class DuplicatesView extends Mn.CompositeView
         # Generate duplicates list.
         @collection = new Duplicates null, collection: contacts
         @toMerge = new BackboneProjections.Filtered @collection,
-            filter: (merge) -> merge.isMergeable()
+            filter: (merge) ->
+                merge.isMergeable()
 
         @bindEntityEvents @collection, @getOption 'collectionEvents'

--- a/client/app/views/models/merge.coffee
+++ b/client/app/views/models/merge.coffee
@@ -160,4 +160,7 @@ module.exports = class MergeViewModel extends Backbone.ViewModel
 
             # Add the contacts after trigger, because add to main contacts
             # collection is a sensitive overhead (~1s)
-            require('application').contacts.add result
+            app = require('application')
+            app.contacts.disableSort()
+            app.contacts.add result
+            app.contacts.enableSort()


### PR DESCRIPTION
* This PR rewrites the similar contacts search algorithm (based on a map instead of the two nested fors)
* It disables sorting when contact is added to the collection after a merge.