### PR TITLE
Add tag to selected contacts

### DIFF
--- a/client/app/locales/en.json
+++ b/client/app/locales/en.json
@@ -8,6 +8,7 @@
     "tools actions find duplicates": "find duplicates",
     "tools search placeholder":      "search for contacts",
     "tools labels filters":          "labels",
+    "tools labels filters selected": "selected label",
     "tools labels filters all":      "all contacts",
     "tools labels admin":            "add label",
     "tools contextual selected":     "%{smart_count} contact selected |||| %{smart_count} contacts selected",

--- a/client/app/locales/en.json
+++ b/client/app/locales/en.json
@@ -9,6 +9,7 @@
     "tools search placeholder":      "search for contacts",
     "tools labels filters":          "labels",
     "tools labels filters all":      "all contacts",
+    "tools labels admin":            "add label",
     "tools contextual selected":     "%{smart_count} contact selected |||| %{smart_count} contacts selected",
     "tools contextual select all":   "select all",
     "tools contextual select none":  "select none",

--- a/client/app/locales/fr.json
+++ b/client/app/locales/fr.json
@@ -7,6 +7,7 @@
     "tools actions find duplicates": "doublons",
     "tools search placeholder": "rechercher des contacts",
     "tools labels filters": "libellés",
+    "tools labels filters selected": "libellé sélectionné",
     "tools labels filters all": "tous les contacts",
     "tools labels admin": "Ajouter un libéllé",
     "tools contextual selected": "%{smart_count} contact sélectionné |||| %{smart_count} contacts sélectionnés",

--- a/client/app/locales/fr.json
+++ b/client/app/locales/fr.json
@@ -8,6 +8,7 @@
     "tools search placeholder": "rechercher des contacts",
     "tools labels filters": "libellés",
     "tools labels filters all": "tous les contacts",
+    "tools labels admin": "Ajouter un libéllé",
     "tools contextual selected": "%{smart_count} contact sélectionné |||| %{smart_count} contacts sélectionnés",
     "tools contextual select all": "tout sélectionner",
     "tools contextual select none": "tout désélectionner",

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -181,12 +181,22 @@ module.exports = class AppLayout extends Mn.LayoutView
         unless slug
             @dialogs.empty()
         else
+            # Remove old listeners
+            # before updating DialogsRegion
+            if (dialogs = @getChildView 'dialogs')
+                dialogs.stopListening dialogs.model, 'change:tags'
+
             dialogView = switch slug
                 when 'settings'   then new SettingsView model: @model
                 when 'duplicates' then new DuplicatesView()
                 else                   @_buildContactView slug
-
             @showChildView 'dialogs', dialogView
+
+            # Should upgrade LabelsSelectView
+            dialogs = @getChildView 'dialogs'
+            dialogs.listenTo dialogs.model, 'change:tags', (args...) =>
+                labels = @getChildView 'labels'
+                labels.trigger 'change:tags', [args...]
 
 
     _buildContactView: (id) ->

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -121,12 +121,12 @@ module.exports = class AppLayout extends Mn.LayoutView
         el.scrollTop += el.offsetHeight
 
 
-    showContextualMenu: (selected) ->
+    showContextualMenu: ->
         @showChildView 'labels', new LabelsSelectView  model: @model
         @showChildView 'actions', new ContextActionsTool model: @model
 
-    hideContextualMenu: (selected) ->
-        @showChildView 'labels', new LabelsFiltersView  model: @model
+    hideContextualMenu: ->
+        @showFilters()
         @showChildView 'actions', new DefaultActionsTool()
 
 

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -57,7 +57,8 @@ module.exports = class AppLayout extends Mn.LayoutView
 
     modelEvents:
         'change:dialog':   'showDialog'
-        'change:selected': 'swapContextualMenu'
+        'select:start':    'showContextualMenu'
+        'select:none':     'hideContextualMenu'
         'change:scored':   'onSearchResults'
 
     childEvents:
@@ -117,21 +118,11 @@ module.exports = class AppLayout extends Mn.LayoutView
         el = @ui.content[0]
         el.scrollTop += el.offsetHeight
 
+    showContextualMenu: ->
+        @showChildView 'actions', new ContextActionsTool model: @model
 
-    # Contextual Region actions
-    #
-    # - toggle the drawer on small screens
-    # - switch contextual menu view when rows are selected
-    # ##########################################################################
-    swapContextualMenu: (appViewModel, selected) ->
-        prev = appViewModel._previousAttributes.selected
-        return if prev.length and selected.length
-
-        if _.isEmpty selected
-            @showChildView 'actions', new DefaultActionsTool()
-        else
-            @showChildView 'actions', new ContextActionsTool model: @model
-
+    hideContextualMenu: ->
+        @showChildView 'actions', new DefaultActionsTool()
 
     toggleDrawer: ->
         $drawer = @$ 'aside.drawer'
@@ -217,4 +208,3 @@ module.exports = class AppLayout extends Mn.LayoutView
             @ui.counter
             .text t 'error search too short'
             .addClass 'important'
-

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -58,7 +58,7 @@ module.exports = class AppLayout extends Mn.LayoutView
     modelEvents:
         'change:dialog':   'showDialog'
         'select:start':    'showContextualMenu'
-        'select:none':     'hideContextualMenu'
+        'select:end':      'hideContextualMenu'
         'change:scored':   'onSearchResults'
 
     childEvents:

--- a/client/app/views/contacts/index.coffee
+++ b/client/app/views/contacts/index.coffee
@@ -172,7 +172,6 @@ module.exports = class Contacts extends Mn.CompositeView
         selected = event.currentTarget.checked
         id       = event.currentTarget.value
         method   = if selected then 'contacts:select' else 'contacts:unselect'
-
         @triggerMethod method, id
 
 

--- a/client/app/views/labels/admin.coffee
+++ b/client/app/views/labels/admin.coffee
@@ -15,13 +15,17 @@ module.exports = class LabelsAdminToolView extends Mn.CompositeView
 
     childView: require 'views/labels/select'
 
-
     childEvents:
         'label:update': 'changeSelection'
 
 
     modelEvents:
         'change:selected': 'updateSelection'
+
+
+    initialize: (args) ->
+        super args...
+        @listenTo @, 'change:tags', @updateSelection
 
 
     select: (model, models) =>
@@ -48,7 +52,6 @@ module.exports = class LabelsAdminToolView extends Mn.CompositeView
             app = require 'application'
             @collection = new Filtered app.tags,
                 filter: (model) ->
-                    console.log 'filter', model
                     app.contacts.tagMap[model.get('name')]?
 
         # Upgrade selected values

--- a/client/app/views/labels/admin.coffee
+++ b/client/app/views/labels/admin.coffee
@@ -1,0 +1,64 @@
+{Filtered, Sorted}  = BackboneProjections
+
+_selected = []
+
+class SelectCollection extends Filtered
+    # constructor: (underlying, subtrahend, options = {}) ->
+    #     # options.filter = (model) -> not subtrahend.contains(model)
+    #
+    #     console.log 'new SelectCollection', underlying, options
+    #     super underlying, options
+
+module.exports = class LabelsAdminToolView extends Mn.CompositeView
+
+    template: require 'views/templates/labels/admin'
+
+    tagName: 'fieldset'
+
+
+    behaviors:
+        Navigator: {}
+
+
+    childViewContainer: 'ul'
+
+    childView: require 'views/labels/select'
+
+
+    childEvents:
+        'contacts:update': 'updateBulkSelection'
+
+
+    initialize: ->
+        app = require 'application'
+
+        # TODO : handle mixed selection
+        # TODO : sort tags (top = selected tags)
+
+        @setSelected()
+        @collection = new SelectCollection app.tags,
+            filter: (model) =>
+                if (filter = app.contacts.tagMap[model.get('name')]?)
+                    value = _.contains @getSelected(), model.get('name')
+                    model.set 'selected', value, silent: true
+                filter
+
+
+    setSelected: ->
+        app = require 'application'
+        result = []
+        selected = @model.get 'selected'
+        app.filtered.get(tagged: true).map (contact) ->
+            if _.contains selected, contact.id
+                result.push contact.get('tags')
+        _selected = _.compact _.flatten result
+        _selected
+
+
+    getSelected: ->
+        _selected
+
+
+    updateBulkSelection: (event, tag) ->
+        model = @collection.findWhere({ id: tag.id })
+        model.set({ selected: tag.selected })

--- a/client/app/views/labels/index.coffee
+++ b/client/app/views/labels/index.coffee
@@ -3,7 +3,7 @@
 
 module.exports = class LabelsFiltersToolView extends Mn.CompositeView
 
-    template: require 'views/templates/labels'
+    template: require 'views/templates/labels/index'
 
     tagName: 'fieldset'
 

--- a/client/app/views/labels/select.coffee
+++ b/client/app/views/labels/select.coffee
@@ -1,0 +1,15 @@
+module.exports = class LabelSelect extends Mn.ItemView
+
+    template: require 'views/templates/labels/select'
+
+    tagName: 'li'
+
+    events:
+        'change input[type="checkbox"]': 'select'
+
+
+    # FIXME : should move this elsewhere?
+    select: (event) ->
+        @triggerMethod 'contacts:update',
+            id: event.currentTarget.id
+            selected: !!event.currentTarget.checked

--- a/client/app/views/labels/select.coffee
+++ b/client/app/views/labels/select.coffee
@@ -7,9 +7,8 @@ module.exports = class LabelSelect extends Mn.ItemView
     events:
         'change input[type="checkbox"]': 'select'
 
-
     # FIXME : should move this elsewhere?
     select: (event) ->
-        @triggerMethod 'contacts:update',
+        @triggerMethod 'label:update',
             id: event.currentTarget.id
             selected: !!event.currentTarget.checked

--- a/client/app/views/models/app.coffee
+++ b/client/app/views/models/app.coffee
@@ -34,17 +34,19 @@ module.exports = class AppViewModel extends Backbone.ViewModel
 
 
     select: (id) ->
-        select = @get 'selected'
+        select = _.clone @get 'selected'
         test = _.isEmpty select
         select.push id
-        @set selected: select
-        @trigger 'select:start' if test
+        @set {selected: select}, {silent: true}
 
+        @trigger 'select:start' if test
+        @trigger 'change:selected', @, select
 
     unselect: (id) ->
         select = _.clone @get('selected')
         select = _.without select, id
         @set selected: select
+
         @trigger 'select:end' if _.isEmpty select
 
 

--- a/client/app/views/models/app.coffee
+++ b/client/app/views/models/app.coffee
@@ -35,26 +35,29 @@ module.exports = class AppViewModel extends Backbone.ViewModel
 
     select: (id) ->
         select = @get 'selected'
-        @trigger 'select:start' if _.isEmpty select
+        test = _.isEmpty select
         select.push id
         @set selected: select
+        @trigger 'select:start' if test
 
 
     unselect: (id) ->
         select = _.clone @get('selected')
         select = _.without select, id
-        @trigger 'select:none' if _.isEmpty select
         @set selected: select
+        @trigger 'select:end' if _.isEmpty select
 
 
     selectAll: ->
+        test = _.isEmpty @get 'selected'
         select = app.filtered.get(tagged: true).map (contact) -> contact.id
         @set selected: select
+        @trigger 'select:start' if test
 
 
     unselectAll: ->
         @set selected: []
-        @trigger 'select:none'
+        @trigger 'select:end' unless _.isEmpty @get('selected')
 
 
     # Delete currently selected conctacts.

--- a/client/app/views/models/app.coffee
+++ b/client/app/views/models/app.coffee
@@ -34,13 +34,16 @@ module.exports = class AppViewModel extends Backbone.ViewModel
 
 
     select: (id) ->
-        select = @attributes.selected.slice(0)
+        select = @get 'selected'
+        @trigger 'select:start' if _.isEmpty select
         select.push id
         @set selected: select
 
 
     unselect: (id) ->
-        select = _.without @attributes.selected, id
+        select = _.clone @get('selected')
+        select = _.without select, id
+        @trigger 'select:none' if _.isEmpty select
         @set selected: select
 
 
@@ -51,6 +54,7 @@ module.exports = class AppViewModel extends Backbone.ViewModel
 
     unselectAll: ->
         @set selected: []
+        @trigger 'select:none'
 
 
     # Delete currently selected conctacts.
@@ -132,4 +136,3 @@ module.exports = class AppViewModel extends Backbone.ViewModel
                     @set 'errors', upload: 'error upload wrong filetype'
         else
             @set 'errors', upload: 'error upload wrong filetype'
-

--- a/client/app/views/models/app.coffee
+++ b/client/app/views/models/app.coffee
@@ -32,6 +32,13 @@ module.exports = class AppViewModel extends Backbone.ViewModel
             @unselectAll()
             @set 'scored', require('config').search.pattern('text').test value
 
+        # Save tag filter
+        @listenTo app.channel, 'filter:tag': @setFilter
+
+
+    setFilter: (tag, previous) ->
+        @model.set 'filter': tag
+
 
     select: (id) ->
         select = _.clone @get 'selected'

--- a/client/app/views/templates/labels/admin.jade
+++ b/client/app/views/templates/labels/admin.jade
@@ -1,0 +1,4 @@
+legend= t('tools labels admin')
+nav: form
+    ul
+        li

--- a/client/app/views/templates/labels/admin.jade
+++ b/client/app/views/templates/labels/admin.jade
@@ -1,3 +1,6 @@
+p= t('tools labels filters selected')
+    = filter
+
 legend= t('tools labels admin')
 nav: form
     ul

--- a/client/app/views/templates/labels/index.jade
+++ b/client/app/views/templates/labels/index.jade
@@ -4,4 +4,4 @@ nav: ul
         - var _default = true
         - var name = t('tools labels filters all')
         - var selected = filter == null
-        include ./filter.jade 
+        include ./filter.jade

--- a/client/app/views/templates/labels/select.jade
+++ b/client/app/views/templates/labels/select.jade
@@ -1,0 +1,4 @@
+span(data-input="checkbox" aria-checked=selected)
+    input(type="checkbox" id=id name="label-select" checked=selected)
+    label(for=id)
+    = name


### PR DESCRIPTION
I want to add tags to a contact selection list.

 - I choose 3 contacts,
 - a list of tags appear in contextual menu (radio button list disappear),
 - I can choose one or more tags (select/unselect),
 - those tags are added/removes from selected contacts.
 - I see filter value on top of tags list

then 

 - I click on a selected contact row
 - modal appears
 - I click on 'labels'
 - add/remove/select tag menu appears
 - I add a label : this label is added to contextual menu
 - I remove a label : this label is removed from the contextual menu
 - I select a label : this label is selected into the contextual menu

## Feature

### Current filter
 - [x] show current filter into contextual Menu
 - [ ] define design 

### ContactList actions
##### I select some contacts (select:start)
- [x] show contextual menu
- [x] default menu is hidden
- [x] display a list of tags with checkbox
- [x] select/unselect used/unused tags

##### select/unselect some tags (‘tags:select’)
 - [x] save tags selected as a list
 - [x] update tags into contacts

##### select/unselect some contact (‘contacts:select’)
 - [x] update selection into tagContextView 

##### if no selection (select:end)
 - [x] contextual menu disappear

##### Handle mixed-checkbox feature (selected=mixed)
- [ ] if a tag is not checked for all, use ‘mixed’ value
https://www.w3.org/TR/wai-aria/states_and_properties#aria-checked 

#### TagModal display
##### I add a label
 - [x] this label is added to contextual menu

##### I select a label : 
 - [x] this label is selected into the contextual menu

##### I unselect a label
 - [x] this label is unselected from the contextual menu

## Tests
 - [ ] add test on model
 - [ ] add test on ViewModel
 - [ ] add test on View (events triggered)