### PR TITLE
Improve models lifecycles

### DIFF
--- a/client/app/collections/contacts.coffee
+++ b/client/app/collections/contacts.coffee
@@ -2,7 +2,6 @@ ContactsListener = require 'lib/contacts_listener'
 Contact = require 'models/contact'
 
 
-
 module.exports = class Contacts extends Backbone.Collection
 
     model: Contact
@@ -10,29 +9,12 @@ module.exports = class Contacts extends Backbone.Collection
 
     sortDisabled: false
 
-    buildComparator: (sort) =>
-        fn = (a, b) =>
-            if fn.sort is 'gn'
-                return a.get('n').localeCompare b.get('n')
-            else
-                nameA = a.getLastAndFirstNames()
-                nameB = b.getLastAndFirstNames()
-                return nameA.localeCompare nameB
-
-        fn.sort = sort
-        return fn
-
 
     initialize: ->
         {model} = require 'application'
 
-        @comparator = @buildComparator model.get 'sort'
-
-        @listenTo model, 'change:sort', (nil, sort) =>
-            @comparator.sort = sort
-            @sort()
-
-        @listenTo @, 'change:n', @sort
+        @comparator = 'sortedName'
+        @listenTo model, 'change:sort': _.ary @sort, 0
 
         @contactListener = new ContactsListener()
         @listenToOnce @, 'sync', -> @contactListener.watch @
@@ -106,4 +88,3 @@ module.exports = class Contacts extends Backbone.Collection
                     setTimeout @contactListener.enable, 1000
 
         setTimeout processCards, 35
-

--- a/client/app/collections/filtered.coffee
+++ b/client/app/collections/filtered.coffee
@@ -1,155 +1,78 @@
 ContactViewModel = require 'views/models/contact'
 
-{indexes} = require 'config'
-tagRegExp = require('config').search.pattern 'tag'
+{indexes, search} = require 'config'
+
+tagRegExp = search.pattern 'tag'
 app       = null
+scores    = new WeakMap()
 
 
-ordering = (underlying, scores) ->
-    fn = (a, b) ->
-        if fn.scored
-            (scores.get(b?.model) or 0) - scores.get(a.model)
-        else
-            underlying.indexOf(a.model) - underlying.indexOf(b?.model)
-
-    fn.scored = false
-    return fn
+filter = _.curry (query, model) ->
+    if query
+        {score} = model.match query
+        unless score
+            scores.delete model
+            return false
+        scores.set model, score
+    return true
 
 
 module.exports = class FilteredCollection
 
+    comparator: 'model.attributes.sortedName'
+
+    query: null
+
     constructor: ->
         app = require 'application'
 
-        @sortIdx = if app.model.get('sort') is 'fn' then 0 else 1
-
-        @underlying = app.contacts
         @models     = []
-        @scores     = new WeakMap()
-        @indexes    = new Map Array::map.call indexes, (char) -> [char, []]
-        @query      = null
-        @comparator = ordering @underlying, @scores
+        @indexes    = new Map Array::map.call indexes, (char) ->
+            vmodels = []
+            vmodels.channel = Backbone.Radio.channel "idx.#{char}"
+            [char, vmodels]
 
         @listenTo app.model,
-            'change:scored': (nil, scored) => @comparator.scored = scored
+            'change:sort': @reset
+            'change:scored': (nil, scored) ->
+                @comparator = if scored
+                    (a, b) -> (scores.get(b?.model) or 0) - scores.get(a.model)
+                else 'model.attributes.sortedName'
 
-        @listenTo app.channel, 'filter:text': @updateQuery
+        @listenTo app.channel, 'filter:text': @setQuery
 
-        @listenTo @underlying,
-            'reset':  @reset
-            'update': -> @trigger 'update', @
-            'add':    (model) ->
-                @add [model]
-            'remove': (model) ->
-                @remove @models.filter (vmodel) -> vmodel.model is model
-            'sort':   ->
-                @sortIdx = if app.model.get('sort') is 'fn' then 0 else 1
-                @sort()
-                @resetIndexes()
-
-
-    _filter: (model) =>
-        if @query?
-            {score} = model.match @query
-            unless score
-                @scores.delete model
-                return false
-            @scores.set model, score
-        return true
+        @listenTo app.contacts,
+            'reset':             @reset
+            'add':               @add
+            'remove':            @remove
+            'change:sortedName': (model) ->
+                vmodel = _.find @models, (vmodel) -> vmodel.model is model
+                return unless vmodel
+                @migrateIndex vmodel
 
 
-    updateIndex: (vmodel, sorted = true) ->
-        initial = vmodel.get('initials')[@sortIdx]?.toLowerCase() or ''
-        set = @indexes.get( if /[a-z]/.test initial then initial else '#' )
-
-        return vmodel if _.includes set, vmodel
-
-        if sorted
-            idx = _.sortedIndex set, vmodel, @comparator
-            set.splice idx, 0, vmodel
-        else
-            set.push vmodel
-
-        return vmodel
-
-
-    resetIndexes: ->
-        @indexes.forEach (indexArray) ->
-            indexArray.length = 0
-
-        @models.forEach (vmodel) =>
-            @updateIndex vmodel, false
-
-        @trigger 'reset', @
-
-
-    updateQuery: (query) ->
+    # Helpers handlers
+    # ################
+    setQuery: (query) ->
         @query = query
+
         if query
-            res = @underlying.filter @_filter
-
-            # Reduce to get max score and get a median limit, then excludes all
-            # results $lt it.
-            maxScore = res.reduce (currentMax, model) =>
-                Math.max currentMax, @scores.get model
-            , 0
-
-            if maxScore > 5
-                median = maxScore / 2
-                res = res.filter (model) => @scores.get(model) > median
+            res = app.contacts.filter filter @query
 
             toKeep   = @models.filter (vmodel) -> _.includes res, vmodel.model
-            toRemove = _.difference @models, toKeep
             toAdd    = _.difference res, toKeep.map (vmodel) -> vmodel.model
+            toRemove = _.chain @models
+                .difference toKeep
+                .map (vmodel) -> vmodel.model
+                .value()
 
             @remove toRemove
             @sort()
             @add toAdd
+
             @trigger 'update', @
         else
             @reset()
-
-
-    add: (models) ->
-        opts =
-            add: true
-            remove: false
-            merge: false
-
-        models.forEach (model) =>
-            return unless @_filter model
-
-            vmodel = new ContactViewModel {}, model: model
-
-            idx = _.sortedIndex @models, vmodel, @comparator
-            @models.splice idx, 0, vmodel
-
-            @updateIndex vmodel
-
-            @_modelEvents 'add', vmodel, opts
-
-
-    remove: (vmodels) ->
-        vmodels.forEach (vmodel) =>
-            return unless _.includes @models, vmodel
-
-            @indexes.forEach (set) -> _.pull set, vmodel
-            _.pull @models, vmodel
-
-            @_modelEvents 'remove', vmodel
-
-
-    sort: ->
-        @models.sort @comparator
-        @trigger 'sort', @
-
-
-    reset: ->
-        @models = @underlying
-            .filter @_filter
-            .map (model) -> new ContactViewModel {}, model: model
-
-        @resetIndexes()
 
 
     get: (opts = {}) ->
@@ -162,10 +85,92 @@ module.exports = class FilteredCollection
             base
 
 
-    _modelEvents: (eventName, vmodel, opts= {}) ->
-        args = [eventName, vmodel, @, opts]
-        @trigger.apply vmodel, args
-        @trigger.apply @, args
+    # Internal models collection handlers
+    # ###################################
+    reset: ->
+        @models = app.contacts
+            .filter filter @query
+            .map (model) -> new ContactViewModel {}, model: model
+
+        @resetIndexes()
+
+        @trigger 'reset', @
+
+
+    add: (models) ->
+        models = if _.isArray models then _.clone models else [models]
+
+        models.forEach (model) =>
+            return unless filter(@query, model)
+
+            vmodel = new ContactViewModel {}, model: model
+
+            idx = _.sortedIndex @models, vmodel, @comparator
+            @models.splice idx, 0, vmodel
+
+            @addToIndex vmodel
+            @trigger 'add', vmodel, @, {add:true, index: idx}
+
+
+    remove: (models) ->
+        models  = if _.isArray models then _.clone models else [models]
+        vmodels = @models.filter (vmodel) -> vmodel.model in models
+
+        vmodels.forEach (vmodel) =>
+            _.pull @models, vmodel
+            @removeFromIndex vmodel
+            @trigger 'remove', vmodel, @
+
+
+    sort: ->
+        @models = _.sortBy @models, @comparator
+        @trigger 'sort', @
+
+
+    # Indexes collections handlers
+    # ############################
+    resetIndexes: ->
+        @indexes.forEach (set) -> set.length = 0
+        @models.forEach (vmodel) => @addToIndex vmodel, silent: true
+        @indexes.forEach (set) -> set.channel.trigger 'reset', set, {}
+
+
+    addToIndex: (vmodel, opts = {}) ->
+        set = @indexes.get vmodel.getIndexKey()
+
+        return vmodel if _.includes set, vmodel
+
+        idx = _.sortedIndex set, vmodel, @comparator
+        set.splice idx, 0, vmodel
+
+        unless opts.silent
+            set.channel.trigger 'add', vmodel, set, {add: true, index: idx}
+
+        return vmodel
+
+
+    removeFromIndex: (vmodel, opts = {}) ->
+        if opts.all
+            @indexes.forEach (set) ->
+                len = set.length
+                set = _.pull set, vmodel
+                if len isnt set.length and not opts.silent
+                    set.channel.trigger 'remove', vmodel, set
+
+        else
+            set = @indexes.get(vmodel.getIndexKey())
+            _.pull set, vmodel
+
+            unless opts.silent
+                set.channel.trigger 'remove', vmodel, set
+
+
+    migrateIndex: (vmodel) ->
+        newSet  = @indexes.get vmodel.getIndexKey()
+        return if _.includes newSet, vmodel
+
+        @removeFromIndex vmodel, all: true
+        @addToIndex vmodel
 
 
 _.extend FilteredCollection.prototype, Backbone.Events

--- a/client/app/lib/contacts_listener.coffee
+++ b/client/app/lib/contacts_listener.coffee
@@ -40,8 +40,6 @@ module.exports = class ContactsListener extends CozySocketListener
             Remote action occured (#{queue}, #{action}), processing start!
             """
 
-            @end = new Date().getTime()
-
             nbOccurences = @queues[queue].length
 
             # Build batches of 50 models on which to perform operations.

--- a/client/app/models/contact.coffee
+++ b/client/app/models/contact.coffee
@@ -1,3 +1,6 @@
+app = undefined
+
+
 class Datapoint extends Backbone.Model
     defaults:
         name: 'other'
@@ -23,11 +26,13 @@ module.exports = class Contact extends Backbone.Model
 
         if attrs.n
             [gn, fn, ...] = attrs.n.split ';'
-            attrs.initials = _.chain([fn, gn])
+            attrs.initials = _.chain [fn, gn]
                 .compact()
                 .map (name) -> name[0].toAscii()[0]
                 .join ''
                 .value()
+
+            attrs.sortedName = @_buildSortedName attrs.n
 
         if (url = attrs.url)
             delete attrs.url
@@ -86,6 +91,28 @@ module.exports = class Contact extends Backbone.Model
 
         options.attrs = attrs
         false
+
+
+    _buildSortedName: (n) ->
+        n ?= @get 'n'
+
+        sortKey = app.model.get 'sort'
+        [gn, fn, mn, ...] = n.split ';'
+
+        _.chain if sortKey is 'fn' then [fn, mn, gn] else [gn, fn, mn]
+            .compact()
+            .join ' '
+            .value()
+
+
+    constructor: ->
+        app = require 'application'
+        super
+
+
+    initialize: ->
+        @listenTo app.model, 'change:sort': ->
+            @set 'sortedName': @_buildSortedName()
 
 
     toString: (opts = {}) ->

--- a/client/app/models/contact.coffee
+++ b/client/app/models/contact.coffee
@@ -89,12 +89,10 @@ module.exports = class Contact extends Backbone.Model
 
 
     toString: (opts = {}) ->
-        [gn, fn, ...] = parts = @attributes.n.split ';'
+        [gn, fn, mn, pf, sf] = @attributes.n.split ';'
         # wrap given name (at index 0) in pre/post tags if provided
         gn = _.compact([opts.pre, gn, opts.post]).join ''
-        parts[0] = fn
-        parts[1] = gn
-        _.compact(parts).join ' '
+        _.compact([pf, fn, mn, gn, sf]).join ' '
 
 
     toHighlightedString: (pattern, opts= {})->

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -72,8 +72,9 @@ module.exports = class AppLayout extends Mn.LayoutView
 
         # bind render to collections / appModel events
         @listenToOnce app.tags, 'sync': @showFilters
-        @listenToOnce app.contacts, 'sync': @showContactsList
-        @listenTo app.filtered, 'update': @updateCounter
+        @listenToOnce app.contacts,
+            'sync': @showContactsList
+            'update': @updateCounter
         @listenTo app.model, 'change:filter': @updateCounter
 
         # bind Ui reacts to global channel events
@@ -217,4 +218,3 @@ module.exports = class AppLayout extends Mn.LayoutView
             @ui.counter
             .text t 'error search too short'
             .addClass 'important'
-

--- a/client/app/views/models/app.coffee
+++ b/client/app/views/models/app.coffee
@@ -130,4 +130,3 @@ module.exports = class AppViewModel extends Backbone.ViewModel
                     @set 'errors', upload: 'error upload wrong filetype'
         else
             @set 'errors', upload: 'error upload wrong filetype'
-

--- a/client/app/views/models/contact.coffee
+++ b/client/app/views/models/contact.coffee
@@ -103,6 +103,12 @@ module.exports = class ContactViewModel extends Backbone.ViewModel
         @set 'ref', @model.cid
 
 
+    getIndexKey: ->
+        sortIdx = if app.model.get('sort') is 'fn' then 0 else 1
+        initial = @get('initials')[sortIdx]?.toLowerCase() or ''
+        if /[a-z]/.test initial then initial else '#'
+
+
     onAddField: (type) ->
         @set type, '' if type in CONFIG.xtras
 

--- a/client/app/views/models/contact.coffee
+++ b/client/app/views/models/contact.coffee
@@ -27,10 +27,9 @@ module.exports = class ContactViewModel extends Backbone.ViewModel
         'tags:update':    'updateTags'
         'tags:add':       'addNewTag'
         'form:field:add': 'onAddField'
-        'form:submit':    ->
-            @save()
+        'form:submit':    _.ary @::save, 0
         'export':         'downloadAsVCF'
-        'delete':         -> @destroy()
+        'delete':         _.ary @::destroy, 0
 
 
     proxy: ['toString', 'toHighlightedString', 'match']

--- a/client/app/views/models/merge.coffee
+++ b/client/app/views/models/merge.coffee
@@ -160,5 +160,5 @@ module.exports = class MergeViewModel extends Backbone.ViewModel
 
             # Add the contacts after trigger, because add to main contacts
             # collection is a sensitive overhead (~1s)
-            app = require('application')
-            app.contacts.add result, sort: false
+            {contacts} = require('application')
+            contacts.add result, sort: false

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:jshint": "coffee-jshint --options node,couch ./server/**/*.coffee ./server.coffee",
     "clean": "rm -rf build",
     "tx": "tx pull --all || true",
-    "ensure:client": "cd client && npm update && bower install",
+    "ensure:client": "cd client && npm update --quiet && bower install --quiet",
     "prebuild": "npm-run-all clean tx lint",
     "prebuild:client": "npm run ensure:client",
     "postbuild": "npm-run-all --parallel copy:*",


### PR DESCRIPTION
This PR cleans the models lifecycles events, preventing to trigger useless events in views. It also provides a more clever way to keep sorting in collections and indexes, then allow add action to be done faster.