### PR TITLE
Enable fullsearch mode

### DIFF
--- a/client/app/collections/filtered.coffee
+++ b/client/app/collections/filtered.coffee
@@ -82,7 +82,6 @@ module.exports = class FilteredCollection
                 _scores.push score while score = values.next().value
 
                 median = Math.median _scores
-                console.log median, scores
                 res = res.filter (model) -> scores.get(model) >= median
 
             toKeep   = @models.filter (vmodel) -> _.includes res, vmodel.model

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -87,8 +87,13 @@ module.exports = class AppLayout extends Mn.LayoutView
     # Regions contents rendering
     # ##########################################################################
     onRender: ->
-        @showChildView 'toolbar', new ToolbarView()
+        toolbar = new ToolbarView()
+        @listenToOnce toolbar,
+            'show': -> toolbar.$('#contacts-search').trigger('focus')
+
+        @showChildView 'toolbar', toolbar
         @showChildView 'actions', new DefaultActionsTool()
+
 
 
     showFilters: ->
@@ -98,9 +103,7 @@ module.exports = class AppLayout extends Mn.LayoutView
     showContactsList: ->
         view = new ContactsView collection: app.filtered
 
-        @listenToOnce view, 'show': ->
-            @ui.content.trigger 'focus'
-            @updateCounter()
+        @listenToOnce view, 'show': @updateCounter
 
         @showChildView 'indexes', view
 


### PR DESCRIPTION
This PR:
- enable a full search mode by default (name, organization, datapoints w/o addresses) - refs #170 
- re-enable the median limit which was removed by error
- set focus to search field when app opens