### PR TITLE
Fix dialog height overflow

### DIFF
--- a/client/app/styles/app/_layout.styl
+++ b/client/app/styles/app/_layout.styl
@@ -54,6 +54,10 @@ avatar(size)
     [role=contentinfo]
         max-width 100%
 
+        @media (max-width: (800/basefont)rem)
+            height auto !important
+            min-height 90vh !important
+
     .card
     .duplicates
         [role=contentinfo]


### PR DESCRIPTION
Fix a constraint in dialog height that produces an overflow for long contents such as the editing view on small viewports.