### PR TITLE
Fix error when search query is empty.

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -78,7 +78,9 @@ class Application extends Mn.Application
             filter = filter.replace(_pattern, '')
 
         @model.set 'filter', filter
-        @channel.trigger "filter:#{pattern}", string, last
+
+        if string?
+            @channel.trigger "filter:#{pattern}", string, last
 
 
 # Exports Application singleton instance

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -166,7 +166,7 @@ module.exports = class AppLayout extends Mn.LayoutView
 
 
     toggleResults: (text) ->
-        @results.$el?.attr 'aria-hidden', not text.length
+        @results.$el?.attr 'aria-hidden', not text?.length
 
 
     # Dialogs showing


### PR DESCRIPTION
The error was caused by two things :
* First, a search was always triggered, even if the search query was empty
* Second, the `toggleResults` method was not checking `text` variable's existence before accessing `text.length`

So I fixed those two points.