### PR TITLE
Fix search function for "all contacts" filter

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -79,7 +79,7 @@ class Application extends Mn.Application
 
         @model.set 'filter', filter
 
-        if string? || pattern is 'tag'
+        if string? or pattern is 'tag'
             @channel.trigger "filter:#{pattern}", string, last
 
 

--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -79,7 +79,7 @@ class Application extends Mn.Application
 
         @model.set 'filter', filter
 
-        if string?
+        if string? || pattern is 'tag'
             @channel.trigger "filter:#{pattern}", string, last
 
 


### PR DESCRIPTION
Tag filtering calls search function and "all contacts" filter uses a query empty, so the "all contacts" filter was broken related to #284.
Fixed.