### PR TITLE
Fix contacts filtering when label contains space

### DIFF
--- a/client/app/lib/slugifier.coffee
+++ b/client/app/lib/slugifier.coffee
@@ -1,0 +1,6 @@
+module.exports =
+    slugify: (text) ->
+        return text.replace(/[^-a-zA-Z0-9,&\s]+/ig, '')
+            .replace(/-/gi, '_')
+            .replace(/\s/gi, '-')
+            .toLowerCase()

--- a/client/app/routes/tags.coffee
+++ b/client/app/routes/tags.coffee
@@ -1,3 +1,4 @@
+Slugifier = require '../lib/slugifier'
 app = undefined
 
 module.exports = class TagsRouter extends Backbone.SubRoute
@@ -18,9 +19,16 @@ module.exports = class TagsRouter extends Backbone.SubRoute
             @sheet.deleteRule idx for rule, idx in @sheet.cssRules
 
 
-    filter: (slug) ->
-        app.search 'tag', slug
-
+    filter: (tag) ->
+        app.search 'tag', tag
+        # We determine tag's slug right here. It's a little
+        # bit too late, slugs should set at least when data is parsed
+        # from the server, or directly server-side,
+        # but it implies to change how the tags are working
+        # in the whole application (i.e. use plain objects instead of strings).
+        # This refactoring is too much at this time to fix only this bug.
+        # See https://github.com/cozy/cozy-contacts/issues/262
+        slug = Slugifier.slugify tag
         idx = @sheet.cssRules.length
         @sheet.insertRule """
             [role=row]:not(.tag_#{slug}),

--- a/client/app/routes/tags.coffee
+++ b/client/app/routes/tags.coffee
@@ -1,6 +1,6 @@
 app = undefined
 
-module.exports = class ContactsRouter extends Backbone.SubRoute
+module.exports = class TagsRouter extends Backbone.SubRoute
 
     routes:
         ':slug': 'filter'

--- a/client/app/views/contacts/index.coffee
+++ b/client/app/views/contacts/index.coffee
@@ -1,5 +1,6 @@
 ContactViewModel = require 'views/models/contact'
 ContactRowView   = require 'views/contacts/row'
+Slugifier = require 'lib/slugifier'
 
 Indexes = Backbone.Collection
 
@@ -179,7 +180,10 @@ module.exports = class Contacts extends Mn.CompositeView
             .invoke 'get', 'tags'
             .flatten()
             .compact()
-            .map (tag) -> "tag_#{tag}"
+            # See TagsRouter#filter and
+            # https://github.com/cozy/cozy-contacts/issues/262
+            .map Slugifier.slugify
+            .map (slug) -> "tag_#{slug}"
             .join ' '
             .value()
         if tags.length

--- a/client/app/views/contacts/row.coffee
+++ b/client/app/views/contacts/row.coffee
@@ -1,4 +1,5 @@
 PATTERN = require('config').search.pattern 'text'
+Slugifier = require '../../lib/slugifier'
 
 app = undefined
 
@@ -29,8 +30,15 @@ module.exports = class ContactRow extends Backbone.View
     render: ->
         el   = @el
         data = @serializeData()
+        tags = @model.get 'tags'
 
-        el.className = @model.get('tags')?.map((tag) -> "tag_#{tag}").join(' ')
+        if tags
+            el.className = tags
+                # See TagsRouter#filter and
+                # https://github.com/cozy/cozy-contacts/issues/262
+                .map Slugifier.slugify
+                .map (slug) -> "tag_#{slug}"
+                .join ' '
 
         template     = require 'views/templates/contacts/row'
         el.innerHTML = template data


### PR DESCRIPTION
Fix #262

When a contact label is clicked, it is used as an URL segment to trigger a search.

Also, the label's name is used as a class associated to the HTML element containing contacts info. The mechanism used is to use a CSS hiding to render the filtering (in my opinion we should not rely on DOM logic to handle data logic like filtering, this issue is an evidence).

If the new CSS rule created when a filtering is performed contains a space character, it will be malformed an trigger an error. This error blocks the whole filtering flow.

Fix :

The first idea was to generate slugs server-side or when server data is parsed client-side. But this solution implies to replace actuals tags (which are strings) by objects with who properties `{name, slug}`, and it impacts the whole application.
As the risk of regression was too high, I decided to transform the name into a slug at the last moment, which is the safest solution but absolutely not the better in term of design and calculation time.

Thanks @m4dz to have a review.