### PR TITLE
Prevent Fuzzy to call toLowerCase() on non-string object

### DIFF
--- a/client/app/models/contact.coffee
+++ b/client/app/models/contact.coffee
@@ -180,8 +180,11 @@ module.exports = class Contact extends Backbone.Model
             targets = targets
                 .concat(points)
                 .concat @attributes.tags
-
         score = targets.reduce (memo, target, index) ->
+            # Fuzzy does not check if target is a string before calling
+            # toLowerCase().
+            # See https://github.com/cozy/cozy-contacts/issues/259
+            return unless typeof target is 'string'
             res = fuzzy.match pattern, target
             return memo + (res?.score or 0)
         , 0

--- a/client/app/models/contact.coffee
+++ b/client/app/models/contact.coffee
@@ -184,7 +184,7 @@ module.exports = class Contact extends Backbone.Model
             # Fuzzy does not check if target is a string before calling
             # toLowerCase().
             # See https://github.com/cozy/cozy-contacts/issues/259
-            return unless typeof target is 'string'
+            return memo unless typeof target is 'string'
             res = fuzzy.match pattern, target
             return memo + (res?.score or 0)
         , 0


### PR DESCRIPTION
This PR is supposed to fix #259

This issue seems to occur when Fuzzy.match is called with a non string parameter as `target`.

I was not able to reproduce it manually so I forced the behavior by editing the line https://github.com/cozy/cozy-contacts/blob/master/client/app/models/contact.coffee#L172
to
```coffeescript
        targets = _.compact [@toString(), @attributes.org, {test:'not a string'}]
```
It threw the exact same error.

Thanks @m4dz to have a review.