### PR TITLE
[fix] clean dates on exports

### DIFF
--- a/client/app/models/contact.coffee
+++ b/client/app/models/contact.coffee
@@ -232,6 +232,9 @@ module.exports = class Contact extends Backbone.Model
     toVCF: (callback) ->
         data = @toJSON()
         data.datapoints = data.datapoints.toJSON()
+        # We remove the BDay datapoint if it doesn't match ISO 8601
+        unless moment(data.bday, 'YYYY-MM-DD', true).isValid()
+            delete data['bday']
         @picturetoa (picture) -> callback VCardParser.toVCF data, picture
 
 


### PR DESCRIPTION
Related to #120 

When we do an export, the `bday` field is exported as it. Unfortunately, this field is, at the moment, a free input one. The VCard `bday` field _must_ be an ISO8601 or at least a `YYYY-MM-DD` format. Trying to do a magic with this field to try to detect a manually entered format is a no-way choice. Instead, we made the choice to test the date format and drop the field if it doesn't respect the expected one.

This PR makes this test and pop an error in console to inform about a malformed field.

To perfectly complete the #120 issue, we should:

- force the input format in validation
- plug a datepicker on the field to help input
- inform the user in a notification panel at load that some contacts have malformed fields and invite him/her to fix them manually