### PR TITLE
fix: unsupported field problems

### DIFF
--- a/src/components/ContactCard/ContactCard.jsx
+++ b/src/components/ContactCard/ContactCard.jsx
@@ -39,9 +39,15 @@ export const groupUnsupportedFields = (fields, supportedFieldTypes) => {
   ]);
 };
 export const orderFieldList = (fields, fieldsInOrder) =>
-  fields.sort(
-    (a, b) => fieldsInOrder.indexOf(a.type) - fieldsInOrder.indexOf(b.type)
-  );
+  fields.slice().sort((a, b) => {
+    const indexA = fieldsInOrder.includes(a.type)
+      ? fieldsInOrder.indexOf(a.type)
+      : fieldsInOrder.length;
+    const indexB = fieldsInOrder.includes(b.type)
+      ? fieldsInOrder.indexOf(b.type)
+      : fieldsInOrder.length;
+    return indexA - indexB;
+  });
 export const makeValuesArray = fields =>
   fields.map(field => ({
     ...field,

--- a/src/components/ContactCard/ContactCard.jsx
+++ b/src/components/ContactCard/ContactCard.jsx
@@ -21,7 +21,8 @@ export const getFieldListFrom = contact =>
   Object.keys(contact).map(type => ({ type, values: contact[type] }));
 export const filterFieldList = fields =>
   fields.filter(
-    field => ["name", "_id", "_rev"].includes(field.type) === false
+    field =>
+      ["name", "_id", "_rev"].includes(field.type) === false && field.values
   );
 export const groupUnsupportedFields = (fields, supportedFieldTypes) => {
   const supportedFields = fields.filter(field =>

--- a/src/components/ContactCard/ContactCard.spec.jsx
+++ b/src/components/ContactCard/ContactCard.spec.jsx
@@ -60,6 +60,13 @@ describe("Filter fields", () => {
       filtered.filter(field => ["stays"].includes(field.type)).length
     ).toEqual(1);
   });
+
+  it("should filter out empty values", () => {
+    const filtered = filterFieldList([{ type: "something", values: "" }]);
+
+    expect(filtered).toBeInstanceOf(Array);
+    expect(filtered.length).toEqual(0);
+  });
 });
 
 describe("Group fields", () => {

--- a/src/components/ContactCard/ContactCard.spec.jsx
+++ b/src/components/ContactCard/ContactCard.spec.jsx
@@ -7,7 +7,7 @@ import {
   makeValuesArray
 } from "./ContactCard.jsx";
 
-const shuffleArray = arr => arr.sort(() => Math.random() - 0.5);
+const shuffleArray = arr => arr.slice().sort(() => Math.random() - 0.5);
 
 describe("Transform contacts", () => {
   it("should transform an object into an array of fields", () => {
@@ -168,6 +168,29 @@ describe("Order fields", () => {
     for (let i = 0; i < sorted.length; ++i) {
       expect(sorted[i]).toEqual(fields[i]);
     }
+  });
+
+  it("should put unknown fields at the end", () => {
+    const fields = [
+      { type: "phone", values: "whatever" },
+      { type: "address", values: "whatever" },
+      { type: "cozy", values: "whatever" }
+    ];
+    const sorted = orderFieldList(fields, ["cozy", "address"]);
+
+    expect(sorted).toBeInstanceOf(Array);
+    expect(sorted.length).toEqual(fields.length);
+    expect(sorted[2]).toEqual(fields[0]);
+  });
+
+  it("should not modify the original array", () => {
+    const original = [
+      { type: "phone", values: "whatever" },
+      { type: "address", values: "whatever" }
+    ];
+    const sorted = orderFieldList(original, ["phone", "address"]);
+
+    expect(sorted).not.toBe(original);
   });
 });
 


### PR DESCRIPTION
We had a contact with the following structure:

```
{
  name: { gibenName: 'John' },
  randomField: ''
}
```

This caused 2 problems:

- We displayed a field "other", that contained nothing (`''`)
- That field was displayed before any other field

I fixed the two problems and added tests for theses cases (plus a bonus third one that hadn't caused problems… yet)