### PR TITLE
chore: don't lint before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
 - install -m0644 .transifexrc.tpl ~/.transifexrc
 - echo "password = $TX_PASSWD" >> ~/.transifexrc
 script:
+- yarn lint
 - yarn test
 - yarn build
 after_success:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
       "NODE_ENV=browser:development cozy-scripts --show-config",
     "deploy":
       "git-directory-deploy --username cozy --email contact@cozycloud.cc --directory build/ --repo=https://$GITHUB_TOKEN@github.com/cozy/cozy-contacts.git",
-    "pretest": "npm-run-all --serial lint",
     "test": "jest",
     "stack:docker":
       "docker run --rm -it -p 8080:8080 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev"


### PR DESCRIPTION
While writing tests, I found the linting before the tests quite annoying. The linter will complain about `console.log` statements and other not too important things, and refuse to run the tests until they are fixed.

I also don't think there's a lot of value in linting before testing. They are just 2 different things. What do you think?