### PR TITLE
fix: menu in ContactCard is right positioned

### DIFF
--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -13,6 +13,7 @@ const TranslatedContactCard = ({ ...props }, { t }) => (
 
 const ContactCardMenu = ({ deleteAction }) => (
   <Menu
+    position="right"
     component={
       <Button theme="secondary" extension="narrow">
         <Icon icon="dots" />


### PR DESCRIPTION
Before
![](https://screenshotscdn.firefoxusercontent.com/images/3e95ccf2-a8a2-4e0a-b308-dc86cbae662b.png)

After
![](https://screenshotscdn.firefoxusercontent.com/images/c1e4a1d2-f8d0-4461-b920-ffa0ab81545d.png)

Thanks @ptbrowne for the tips