### PR TITLE
fix: closing button is covered by menu button

### DIFF
--- a/src/styles/contactCard.styl
+++ b/src/styles/contactCard.styl
@@ -62,3 +62,4 @@
 
 .contact-card-header
     display flex
+    max-width 90% // hack, related issue https://github.com/cozy/cozy-ui/issues/337


### PR DESCRIPTION
see https://github.com/cozy/cozy-ui/issues/337

before

![](https://i.imgur.com/ZfxPhm7.png)

after

![](https://i.imgur.com/JmdUCFx.png)