### PR TITLE
feat: add placeholders in contact form

### DIFF
--- a/src/components/ContactCard/ContactFieldForm.jsx
+++ b/src/components/ContactCard/ContactFieldForm.jsx
@@ -24,7 +24,7 @@ class ContactFieldInput extends React.Component {
   };
 
   render() {
-    const { name, type, withLabel } = this.props;
+    const { name, type, placeholder, withLabel, labelPlaceholder } = this.props;
     const { renderLabel } = this.state;
 
     return (
@@ -32,6 +32,7 @@ class ContactFieldInput extends React.Component {
         <Field
           name={name}
           type={type}
+          placeholder={placeholder}
           onFocus={this.showLabel}
           onBlur={this.hideLabelIfEmpty}
           component={getInputComponent(type)}
@@ -44,6 +45,7 @@ class ContactFieldInput extends React.Component {
               type="text"
               component="input"
               className="contact-form__label-input"
+              placeholder={labelPlaceholder}
             />
           )}
       </div>
@@ -53,13 +55,25 @@ class ContactFieldInput extends React.Component {
 ContactFieldInput.propTypes = {
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  withLabel: PropTypes.bool
+  placeholder: PropTypes.string,
+  withLabel: PropTypes.bool,
+  labelPlaceholder: PropTypes.string
 };
 ContactFieldInput.defaultProps = {
-  withLabel: false
+  withLabel: false,
+  placeholder: "",
+  labelPlaceholder: ""
 };
 
-const ContactFieldForm = ({ icon, name, type, label, inputWithLabel }) => (
+const ContactFieldForm = ({
+  icon,
+  name,
+  type,
+  label,
+  placeholder,
+  inputWithLabel,
+  labelPlaceholder
+}) => (
   <div className="contact-form__field">
     <label className="contact-form__label">
       {icon && (
@@ -67,7 +81,13 @@ const ContactFieldForm = ({ icon, name, type, label, inputWithLabel }) => (
       )}
       {label}
     </label>
-    <ContactFieldInput name={name} type={type} withLabel={inputWithLabel} />
+    <ContactFieldInput
+      name={name}
+      type={type}
+      placeholder={placeholder}
+      withLabel={inputWithLabel}
+      labelPlaceholder={labelPlaceholder}
+    />
   </div>
 );
 ContactFieldForm.propTypes = {
@@ -75,11 +95,15 @@ ContactFieldForm.propTypes = {
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  labelPlaceholder: PropTypes.string,
   inputWithLabel: PropTypes.bool
 };
 ContactFieldForm.defaultProps = {
   icon: null,
-  inputWithLabel: false
+  inputWithLabel: false,
+  placeholder: "",
+  labelPlaceholder: ""
 };
 
 export default ContactFieldForm;

--- a/src/components/ContactCard/ContactForm.jsx
+++ b/src/components/ContactCard/ContactForm.jsx
@@ -146,8 +146,10 @@ class ContactForm extends React.Component {
                     icon={icon}
                     name={name}
                     label={t(`field.${name}`)}
+                    placeholder={t(`placeholder.${name}`)}
                     type={type}
                     inputWithLabel={hasLabel}
+                    labelPlaceholder={t("placeholder.label")}
                   />
                 ))}
               </div>

--- a/src/components/ContactCard/__snapshots__/ContactForm.spec.jsx.snap
+++ b/src/components/ContactCard/__snapshots__/ContactForm.spec.jsx.snap
@@ -26,6 +26,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.givenName"
             type="text"
             value=""
           />
@@ -48,6 +49,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.familyName"
             type="text"
             value=""
           />
@@ -84,6 +86,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.phone"
             type="tel"
             value=""
           />
@@ -120,6 +123,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.email"
             type="email"
             value=""
           />
@@ -156,6 +160,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.address"
             type="text"
             value=""
           />
@@ -192,6 +197,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.cozy"
             type="url"
             value=""
           />
@@ -228,6 +234,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.company"
             type="text"
             value=""
           />
@@ -264,6 +271,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.birthday"
             type="date"
             value=""
           />
@@ -300,6 +308,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder="placeholder.note"
             type="textarea"
             value=""
           />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,5 +19,17 @@
     "company": "Company",
     "birthday": "Birthday",
     "note": "Notes"
+  },
+  "placeholder": {
+    "givenName": "Claude",
+    "familyName": "Douillet",
+    "phone": "01 23 45 67 89",
+    "email": "claude@mycozy.cloud",
+    "address": "",
+    "cozy": "",
+    "company": "",
+    "birthday": "",
+    "note": "",
+    "label": "Work"
   }
 }


### PR DESCRIPTION
Adds placeholders to inputs and their labels.

I'm not very happy with the naming [here](https://github.com/cozy/cozy-contacts/compare/master...y-lohse:placeholders?expand=1#diff-9b0be75ed3549475f6997ba1248459d1R148) (`label`, `withLabel`, `labelPlaceholder`) but I don't have a better idea. Suggestions are welcome!