### PR TITLE
fix: disallow creating a contact without name

### DIFF
--- a/src/components/ContactCard/ContactForm.jsx
+++ b/src/components/ContactCard/ContactForm.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Form } from "react-final-form";
-import ContactFieldForm from "./ContactFieldForm";
+import ContactFormField from "./ContactFormField";
 import { Button } from "cozy-ui/react/Button";
 import { translate } from "cozy-ui/react/I18n";
 
@@ -22,7 +22,8 @@ const fields = [
   {
     name: "familyName",
     icon: null,
-    type: "text"
+    type: "text",
+    required: true
   },
   {
     name: "phone",
@@ -140,8 +141,8 @@ class ContactForm extends React.Component {
           <div>
             <form onSubmit={handleSubmit} className="contact-form">
               <div className="contact-form__fields">
-                {fields.map(({ name, icon, type, hasLabel }) => (
-                  <ContactFieldForm
+                {fields.map(({ name, icon, type, required, hasLabel }) => (
+                  <ContactFormField
                     key={name}
                     icon={icon}
                     name={name}
@@ -149,6 +150,7 @@ class ContactForm extends React.Component {
                     placeholder={t(`placeholder.${name}`)}
                     type={type}
                     inputWithLabel={hasLabel}
+                    required={required}
                     labelPlaceholder={t("placeholder.label")}
                   />
                 ))}

--- a/src/components/ContactCard/ContactFormField.jsx
+++ b/src/components/ContactCard/ContactFormField.jsx
@@ -24,7 +24,14 @@ class ContactFieldInput extends React.Component {
   };
 
   render() {
-    const { name, type, placeholder, withLabel, labelPlaceholder } = this.props;
+    const {
+      name,
+      type,
+      placeholder,
+      required,
+      withLabel,
+      labelPlaceholder
+    } = this.props;
     const { renderLabel } = this.state;
 
     return (
@@ -33,6 +40,7 @@ class ContactFieldInput extends React.Component {
           name={name}
           type={type}
           placeholder={placeholder}
+          required={required}
           onFocus={this.showLabel}
           onBlur={this.hideLabelIfEmpty}
           component={getInputComponent(type)}
@@ -57,21 +65,24 @@ ContactFieldInput.propTypes = {
   type: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   withLabel: PropTypes.bool,
+  required: PropTypes.bool,
   labelPlaceholder: PropTypes.string
 };
 ContactFieldInput.defaultProps = {
   withLabel: false,
+  required: false,
   placeholder: "",
   labelPlaceholder: ""
 };
 
-const ContactFieldForm = ({
+const ContactFormField = ({
   icon,
   name,
   type,
   label,
   placeholder,
   inputWithLabel,
+  required,
   labelPlaceholder
 }) => (
   <div className="contact-form__field">
@@ -86,24 +97,27 @@ const ContactFieldForm = ({
       type={type}
       placeholder={placeholder}
       withLabel={inputWithLabel}
+      required={required}
       labelPlaceholder={labelPlaceholder}
     />
   </div>
 );
-ContactFieldForm.propTypes = {
+ContactFormField.propTypes = {
   icon: PropTypes.any, // shall be a SVG prop type
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   labelPlaceholder: PropTypes.string,
-  inputWithLabel: PropTypes.bool
+  inputWithLabel: PropTypes.bool,
+  required: PropTypes.bool
 };
-ContactFieldForm.defaultProps = {
+ContactFormField.defaultProps = {
   icon: null,
   inputWithLabel: false,
+  required: false,
   placeholder: "",
   labelPlaceholder: ""
 };
 
-export default ContactFieldForm;
+export default ContactFormField;

--- a/src/components/ContactCard/__snapshots__/ContactForm.spec.jsx.snap
+++ b/src/components/ContactCard/__snapshots__/ContactForm.spec.jsx.snap
@@ -27,6 +27,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.givenName"
+            required={false}
             type="text"
             value=""
           />
@@ -50,6 +51,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.familyName"
+            required={true}
             type="text"
             value=""
           />
@@ -87,6 +89,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.phone"
+            required={false}
             type="tel"
             value=""
           />
@@ -124,6 +127,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.email"
+            required={false}
             type="email"
             value=""
           />
@@ -161,6 +165,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.address"
+            required={false}
             type="text"
             value=""
           />
@@ -198,6 +203,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.cozy"
+            required={false}
             type="url"
             value=""
           />
@@ -235,6 +241,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.company"
+            required={false}
             type="text"
             value=""
           />
@@ -272,6 +279,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.birthday"
+            required={false}
             type="date"
             value=""
           />
@@ -309,6 +317,7 @@ exports[`ContactForm should match snapshot 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="placeholder.note"
+            required={false}
             type="textarea"
             value=""
           />


### PR DESCRIPTION
It starts to smell when we have to drill down the props like that, doesn't it ?