### PR TITLE
Delete multiple contacts 

### DIFF
--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -33,6 +33,27 @@ ContactsHeaderWithActions.propTypes = {
   displayContactForm: PropTypes.func.isRequired
 };
 
+const SelectionBarWithActions = ({
+  selected,
+  hideSelectionBar,
+  trashAction
+}) => (
+  <SelectionBar
+    selected={selected}
+    hideSelectionBar={hideSelectionBar}
+    actions={{
+      trash: {
+        action: trashAction
+      }
+    }}
+  />
+);
+SelectionBarWithActions.propTypes = {
+  selected: PropTypes.array.isRequired,
+  hideSelectionBar: PropTypes.func.isRequired,
+  trashAction: PropTypes.func.isRequired
+};
+
 class ContactsApp extends React.Component {
   state = {
     displayedContact: null,
@@ -73,26 +94,21 @@ class ContactsApp extends React.Component {
     selection.forEach(contact => {
       this.props.deleteContact(contact);
     });
-    this.clearSelection();
+    this.props.clearSelection();
   };
 
   render() {
     const { displayedContact, isCreationFormDisplayed } = this.state;
     const { t } = this.context;
     const { selection, toggleSelection, clearSelection } = this.props;
-    const actions = {
-      trash: {
-        action: this.deleteSelectedContacts
-      }
-    };
 
     return (
       <main className="app-content">
         {selection.length > 0 && (
-          <SelectionBar
+          <SelectionBarWithActions
             selected={selection}
             hideSelectionBar={clearSelection}
-            actions={actions}
+            trashAction={this.deleteSelectedContacts}
           />
         )}
         <ContactsHeaderWithActions

--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -6,6 +6,7 @@ import OpenContactFormButton from "./Buttons/OpenContactFormButton";
 import ContactsIntentButton from "./Buttons/ContactsIntentButton";
 import ContactCardModal from "./Modals/ContactCardModal";
 import ContactFormModal from "./Modals/ContactFormModal";
+import { SelectionBar } from "cozy-ui/react";
 
 const ContactsHeaderWithActions = ({ displayContactForm }, { t }) => (
   <ContactsHeader
@@ -33,7 +34,8 @@ ContactsHeaderWithActions.propTypes = {
 class ContactsApp extends React.Component {
   state = {
     displayedContact: null,
-    isCreationFormDisplayed: false
+    isCreationFormDisplayed: false,
+    selection: []
   };
 
   displayContactCard = contact => {
@@ -65,17 +67,55 @@ class ContactsApp extends React.Component {
     this.displayContactCard(contact);
   };
 
+  toggleSelection = data => {
+    const index = this.state.selection.indexOf(data);
+    this.setState(state => ({
+      ...state,
+      selection:
+        index === -1
+          ? [...state.selection, data]
+          : [
+              ...state.selection.slice(0, index),
+              ...state.selection.slice(index + 1)
+            ]
+    }));
+  };
+
+  clearSelection = () =>
+    this.setState(state => ({
+      ...state,
+      selection: []
+    }));
+
   render() {
-    const { displayedContact, isCreationFormDisplayed } = this.state;
+    const { displayedContact, isCreationFormDisplayed, selection } = this.state;
     const { t } = this.context;
+    const actions = {
+      trash: {
+        action: () => {
+          console.log("tras shit");
+        }
+      }
+    };
 
     return (
       <main className="app-content">
+        {selection.length > 0 && (
+          <SelectionBar
+            selected={selection}
+            hideSelectionBar={this.clearSelection}
+            actions={actions}
+          />
+        )}
         <ContactsHeaderWithActions
           displayContactForm={this.displayContactForm}
         />
         <div role="contentinfo">
-          <ConnectedContactsList onClickContact={this.displayContactCard} />
+          <ConnectedContactsList
+            onClickContact={this.displayContactCard}
+            onSelect={this.toggleSelection}
+            selection={this.state.selection}
+          />
         </div>
         {displayedContact && (
           <ContactCardModal

--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -7,6 +7,7 @@ import ContactsIntentButton from "./Buttons/ContactsIntentButton";
 import ContactCardModal from "./Modals/ContactCardModal";
 import ContactFormModal from "./Modals/ContactFormModal";
 import { SelectionBar } from "cozy-ui/react";
+import { withDeletion } from "../connections/allContacts";
 
 const ContactsHeaderWithActions = ({ displayContactForm }, { t }) => (
   <ContactsHeader
@@ -89,9 +90,10 @@ class ContactsApp extends React.Component {
 
   deleteSelectedContacts = () => {
     const { selection } = this.state;
-    selection.forEach(id => {
-      console.log("delete contact", id);
+    selection.forEach(contact => {
+      this.props.deleteContact(contact);
     });
+    this.clearSelection();
   };
 
   render() {
@@ -140,6 +142,8 @@ class ContactsApp extends React.Component {
     );
   }
 }
-ContactsApp.propTypes = {};
+ContactsApp.propTypes = {
+  deleteContact: PropTypes.func.isRequired
+};
 
-export default ContactsApp;
+export default withDeletion(ContactsApp);

--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ConnectedContactsList from "./ContactsList";
 import ContactsHeader from "./ContactsList/ContactsHeader";
+import withSelection from "./HOCs/withSelection";
 import { PropTypes } from "prop-types";
 import OpenContactFormButton from "./Buttons/OpenContactFormButton";
 import ContactsIntentButton from "./Buttons/ContactsIntentButton";
@@ -35,8 +36,7 @@ ContactsHeaderWithActions.propTypes = {
 class ContactsApp extends React.Component {
   state = {
     displayedContact: null,
-    isCreationFormDisplayed: false,
-    selection: []
+    isCreationFormDisplayed: false
   };
 
   displayContactCard = contact => {
@@ -68,28 +68,8 @@ class ContactsApp extends React.Component {
     this.displayContactCard(contact);
   };
 
-  toggleSelection = data => {
-    const index = this.state.selection.indexOf(data);
-    this.setState(state => ({
-      ...state,
-      selection:
-        index === -1
-          ? [...state.selection, data]
-          : [
-              ...state.selection.slice(0, index),
-              ...state.selection.slice(index + 1)
-            ]
-    }));
-  };
-
-  clearSelection = () =>
-    this.setState(state => ({
-      ...state,
-      selection: []
-    }));
-
   deleteSelectedContacts = () => {
-    const { selection } = this.state;
+    const { selection } = this.props;
     selection.forEach(contact => {
       this.props.deleteContact(contact);
     });
@@ -97,8 +77,9 @@ class ContactsApp extends React.Component {
   };
 
   render() {
-    const { displayedContact, isCreationFormDisplayed, selection } = this.state;
+    const { displayedContact, isCreationFormDisplayed } = this.state;
     const { t } = this.context;
+    const { selection, toggleSelection, clearSelection } = this.props;
     const actions = {
       trash: {
         action: this.deleteSelectedContacts
@@ -110,7 +91,7 @@ class ContactsApp extends React.Component {
         {selection.length > 0 && (
           <SelectionBar
             selected={selection}
-            hideSelectionBar={this.clearSelection}
+            hideSelectionBar={clearSelection}
             actions={actions}
           />
         )}
@@ -120,8 +101,8 @@ class ContactsApp extends React.Component {
         <div role="contentinfo">
           <ConnectedContactsList
             onClickContact={this.displayContactCard}
-            onSelect={this.toggleSelection}
-            selection={this.state.selection}
+            onSelect={toggleSelection}
+            selection={selection}
           />
         </div>
         {displayedContact && (
@@ -143,7 +124,10 @@ class ContactsApp extends React.Component {
   }
 }
 ContactsApp.propTypes = {
+  selection: PropTypes.array.isRequired,
+  toggleSelection: PropTypes.func.isRequired,
+  clearSelection: PropTypes.func.isRequired,
   deleteContact: PropTypes.func.isRequired
 };
 
-export default withDeletion(ContactsApp);
+export default withSelection(withDeletion(ContactsApp));

--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -87,14 +87,19 @@ class ContactsApp extends React.Component {
       selection: []
     }));
 
+  deleteSelectedContacts = () => {
+    const { selection } = this.state;
+    selection.forEach(id => {
+      console.log("delete contact", id);
+    });
+  };
+
   render() {
     const { displayedContact, isCreationFormDisplayed, selection } = this.state;
     const { t } = this.context;
     const actions = {
       trash: {
-        action: () => {
-          console.log("tras shit");
-        }
+        action: this.deleteSelectedContacts
       }
     };
 

--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -89,11 +89,12 @@ class ContactsApp extends React.Component {
     this.displayContactCard(contact);
   };
 
-  deleteSelectedContacts = () => {
+  deleteSelectedContacts = async () => {
     const { selection } = this.props;
-    selection.forEach(contact => {
-      this.props.deleteContact(contact);
-    });
+    const promises = selection.map(contact =>
+      this.props.deleteContact(contact)
+    );
+    await Promise.all(promises);
     this.props.clearSelection();
   };
 

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -49,9 +49,9 @@ const ContactsList = props => {
                     selection={
                       props.onSelect && {
                         onSelect: () => {
-                          props.onSelect(contact._id);
+                          props.onSelect(contact);
                         },
-                        selected: props.selection.includes(contact._id)
+                        selected: props.selection.includes(contact)
                       }
                     }
                     onClick={e => props.onClickContact(contact, e)}

--- a/src/components/ContactsList/index.js
+++ b/src/components/ContactsList/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { connect, all } from "cozy-client";
+import { withContacts } from "../../connections/allContacts";
 import ContactsList from "./ContactsList";
 import ContactsError from "./ContactsError";
 
@@ -42,6 +42,4 @@ ContactsListWithLoading.propTypes = {
   fetchStatus: PropTypes.string
 };
 
-export default connect(all("io.cozy.contacts"), { as: "allContacts" })(
-  ContactsListWithLoading
-);
+export default withContacts(ContactsListWithLoading);

--- a/src/components/HOCs/withSelection.jsx
+++ b/src/components/HOCs/withSelection.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+const withSelection = WrappedComponent => {
+  return class ComponentWithSelection extends React.Component {
+    state = {
+      selection: []
+    };
+
+    toggleSelection = data => {
+      const index = this.state.selection.indexOf(data);
+      this.setState(state => ({
+        ...state,
+        selection:
+          index === -1
+            ? [...state.selection, data]
+            : [
+                ...state.selection.slice(0, index),
+                ...state.selection.slice(index + 1)
+              ]
+      }));
+    };
+
+    clearSelection = () =>
+      this.setState(state => ({
+        ...state,
+        selection: []
+      }));
+
+    render() {
+      return (
+        <WrappedComponent
+          selection={this.state.selection}
+          toggleSelection={this.toggleSelection}
+          clearSelection={this.clearSelection}
+        />
+      );
+    }
+  };
+};
+
+export default withSelection;

--- a/src/components/HOCs/withSelection.spec.jsx
+++ b/src/components/HOCs/withSelection.spec.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { shallow } from "enzyme";
+import withSelection from "./withSelection";
+
+const DummyComponent = () => <span />;
+const DummyComponentWithSelection = withSelection(DummyComponent);
+
+describe("A component with selection", () => {
+  let testedComponent;
+
+  beforeEach(() => {
+    const root = <DummyComponentWithSelection />;
+    testedComponent = shallow(root);
+  });
+
+  it("should toggle the selection", () => {
+    expect(testedComponent.prop("selection")).toEqual([]);
+
+    testedComponent.prop("toggleSelection")(1);
+    testedComponent.prop("toggleSelection")(2);
+    testedComponent.update();
+
+    expect(testedComponent.prop("selection")).toEqual([1, 2]);
+
+    testedComponent.prop("toggleSelection")(2);
+    testedComponent.update();
+    expect(testedComponent.prop("selection")).toEqual([1]);
+  });
+
+  it("should clear the selection", () => {
+    expect(testedComponent.prop("selection").length).toEqual(0);
+
+    testedComponent.prop("toggleSelection")(1);
+    testedComponent.prop("toggleSelection")(2);
+    testedComponent.update();
+
+    expect(testedComponent.prop("selection").length).toEqual(2);
+
+    testedComponent.prop("clearSelection")();
+    testedComponent.update();
+
+    expect(testedComponent.prop("selection").length).toEqual(0);
+  });
+});

--- a/src/components/Modals/ContactCardModal.jsx
+++ b/src/components/Modals/ContactCardModal.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { PropTypes } from "prop-types";
-import { withMutation, destroy } from "cozy-client";
+import { withDeletion } from "../../connections/allContacts";
 import Modal, { ModalContent } from "cozy-ui/react/Modal";
 import { Icon, Menu, MenuItem, Button } from "cozy-ui/react";
 import ContactCard from "../ContactCard/ContactCard";
@@ -67,12 +67,4 @@ ContactCardModal.propTypes = {
   onDeleteContact: PropTypes.func.isRequired
 };
 
-export default withMutation(destroy, {
-  name: "deleteContact",
-  updateQueries: {
-    allContacts: (previousData, result) => {
-      const idx = previousData.findIndex(c => c.id === result.data[0].id);
-      return [...previousData.slice(0, idx), ...previousData.slice(idx + 1)];
-    }
-  }
-})(ContactCardModal);
+export default withDeletion(ContactCardModal);

--- a/src/components/Modals/ContactFormModal.jsx
+++ b/src/components/Modals/ContactFormModal.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { PropTypes } from "prop-types";
-import { withMutation, create } from "cozy-client";
+import { withCreation } from "../../connections/allContacts";
 import Modal, { ModalTitle, ModalDescription } from "cozy-ui/react/Modal";
 import ContactForm from "../ContactCard/ContactForm";
 
@@ -36,9 +36,4 @@ ContactFormModal.propTypes = {
   onCreateContact: PropTypes.func.isRequired
 };
 
-export default withMutation(create, {
-  name: "createContact",
-  updateQueries: {
-    allContacts: (previousData, result) => [...previousData, result.data[0]]
-  }
-})(ContactFormModal);
+export default withCreation(ContactFormModal);

--- a/src/components/PickContacts.jsx
+++ b/src/components/PickContacts.jsx
@@ -50,7 +50,9 @@ class PickContacts extends React.Component {
   pickContacts = async () => {
     if (this.state.service) {
       try {
-        this.state.service.terminate({ contacts: this.state.selection });
+        this.state.service.terminate({
+          contacts: this.state.selection.map(contact => contact._id)
+        });
       } catch (error) {
         this.state.service.throw(error);
       }

--- a/src/components/PickContacts.jsx
+++ b/src/components/PickContacts.jsx
@@ -5,6 +5,7 @@ import { translate } from "cozy-ui/react/I18n";
 import { Button, IntentHeader } from "cozy-ui/react";
 import ContactsList from "./ContactsList/ContactsList";
 import { withContacts } from "./ContactsList";
+import withSelection from "./HOCs/withSelection";
 
 const ConnectedContactsList = withContacts(ContactsList);
 
@@ -36,8 +37,7 @@ IntentMain.propTypes = {
 
 class PickContacts extends React.Component {
   state = {
-    service: null,
-    selection: []
+    service: null
   };
   async componentDidMount() {
     cozy.client.intents
@@ -51,7 +51,7 @@ class PickContacts extends React.Component {
     if (this.state.service) {
       try {
         this.state.service.terminate({
-          contacts: this.state.selection.map(contact => contact._id)
+          contacts: this.props.selection.map(contact => contact._id)
         });
       } catch (error) {
         this.state.service.throw(error);
@@ -65,20 +65,6 @@ class PickContacts extends React.Component {
     }
   };
 
-  toggleSelection = data => {
-    const index = this.state.selection.indexOf(data);
-    this.setState(state => ({
-      ...state,
-      selection:
-        index === -1
-          ? [...state.selection, data]
-          : [
-              ...state.selection.slice(0, index),
-              ...state.selection.slice(index + 1)
-            ]
-    }));
-  };
-
   render() {
     const { t } = this.props;
     return (
@@ -86,7 +72,7 @@ class PickContacts extends React.Component {
         <IntentHeader appEditor="Cozy" appName="Contacts" appIcon="/icon.svg" />
         <IntentMain>
           <ConnectedContactsList
-            selection={this.state.selection}
+            selection={this.props.selection}
             onSelect={this.toggleSelection}
           />
         </IntentMain>
@@ -95,7 +81,7 @@ class PickContacts extends React.Component {
           onSubmit={this.pickContacts}
           onCancel={this.cancel}
           label={t("selected_contacts", {
-            smart_count: this.state.selection.length
+            smart_count: this.props.selection.length
           })}
         />
       </div>
@@ -104,7 +90,10 @@ class PickContacts extends React.Component {
 }
 PickContacts.propTypes = {
   intentId: PropTypes.string.isRequired,
+  selection: PropTypes.array.isRequired,
+  toggleSelection: PropTypes.func.isRequired,
+  clearSelection: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired
 };
 
-export default translate()(PickContacts);
+export default translate()(withSelection(PickContacts));

--- a/src/connections/allContacts.js
+++ b/src/connections/allContacts.js
@@ -1,0 +1,28 @@
+import { connect, all, withMutation, create, destroy } from "cozy-client";
+
+const CONNECTION_NAME = "allContacts";
+
+export const withContacts = component =>
+  connect(all("io.cozy.contacts"), { as: CONNECTION_NAME })(component);
+
+export const withCreation = component =>
+  withMutation(create, {
+    name: "createContact",
+    updateQueries: {
+      [CONNECTION_NAME]: (previousData, result) => [
+        ...previousData,
+        result.data[0]
+      ]
+    }
+  })(component);
+
+export const withDeletion = component =>
+  withMutation(destroy, {
+    name: "deleteContact",
+    updateQueries: {
+      [CONNECTION_NAME]: (previousData, result) => {
+        const idx = previousData.findIndex(c => c.id === result.data[0].id);
+        return [...previousData.slice(0, idx), ...previousData.slice(idx + 1)];
+      }
+    }
+  })(component);


### PR DESCRIPTION
A few things to look at:

- Since the regular app and the intent app now both have a selection, [I abstracted the selection logic into a HOC](https://github.com/cozy/cozy-contacts/pull/72/files#diff-ed03cf51242639d21e6ad9d5ede5c077R1)
- We can now delete a contact in 2 places, the `ContactCardModal` and the `ContactApp`. This means we want to connect 2 components with `cozy-client`, [so I moved the `cozy-client` declarations to a separate file](https://github.com/cozy/cozy-contacts/pull/72/files#diff-4185df2a7462c2c13eff6aa810d3b42bR1). I could be further abstracted but there's no need for that right now.
- In order to delete a contact at the `ContactApp` level, we needed the full contact information, not just the `id`. So I [changed the `ContactList`](https://github.com/cozy/cozy-contacts/pull/72/files#diff-b8c853e56cc8b58d63005d12ea0c27c1R52) and [rewrote the intent so that it stills returns a list of ids](https://github.com/cozy/cozy-contacts/pull/72/files#diff-d814289f3c4170f5aba52d001e4378b4R53)
- Finally, I added the [`SelectionBar` from cozy-ui](https://github.com/cozy/cozy-contacts/pull/72/files#diff-b5b123b65f648395a7716fa02882b0b0R36), [I display it when there's a selection](https://github.com/cozy/cozy-contacts/pull/72/files#diff-b5b123b65f648395a7716fa02882b0b0R108), and [added the function that deletes multiples contacts](https://github.com/cozy/cozy-contacts/pull/72/files#diff-b5b123b65f648395a7716fa02882b0b0R92)