### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"],
+  "pinVersions": true,
+  "schedule": ["after 9pm and before 6am on every weekday", "every weekend"],
+  "timezone": "Europe/Paris",
+  "devDependencies": {
+    "automerge": true
+  }
 }


### PR DESCRIPTION
Less renovate noise:

- run at night to reduce github notifications during working hours
- automerge devDependencies so we don't even have to care about those