### PR TITLE
fix: make the cancel button not a submit button

### DIFF
--- a/src/components/ContactCard/ContactForm.jsx
+++ b/src/components/ContactCard/ContactForm.jsx
@@ -158,7 +158,7 @@ class ContactForm extends React.Component {
 
               <div className="contact-form__footer">
                 <div>
-                  <Button theme="secondary" onClick={onCancel}>
+                  <Button type="button" theme="secondary" onClick={onCancel}>
                     {t("cancel")}
                   </Button>
                   <Button type="submit">{t("save")}</Button>


### PR DESCRIPTION
Right now this does nothing at all, but in the next version of cozy-ui, the type will be propagated and validating the form with the enter key will work 👍 