### PR TITLE
fix: filter out id field

### DIFF
--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -13,8 +13,9 @@ export const getFieldListFrom = contact =>
 export const filterFieldList = fields =>
   fields.filter(
     field =>
-      ["name", "fullname", "_id", "_rev", "_type"].includes(field.type) ===
-        false && field.values
+      ["name", "fullname", "_id", "_rev", "_type", "id"].includes(
+        field.type
+      ) === false && field.values
   );
 export const groupUnsupportedFields = (fields, supportedFieldTypes) => {
   const supportedFields = fields.filter(field =>

--- a/src/helpers/contacts.spec.js
+++ b/src/helpers/contacts.spec.js
@@ -11,6 +11,7 @@ describe("Manage Contacts fields", () => {
   test("full transformation", () => {
     const contact = {
       _id: "c6899688-6cc6-4ffb-82d4-ab9f9b82c582",
+      id: "c6899688-6cc6-4ffb-82d4-ab9f9b82c582",
       _rev: "1-9368a4f2e467c449f4a1f5171a784aa8",
       _type: "io.cozy.contacts",
       address: [


### PR DESCRIPTION
After adding cozy-client, the `_id` field is also exported as `id`, but we don't want it to appear either.