### PR TITLE
chore: remove react-select dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "preact": "8.2.7",
     "preact-compat": "3.18.0",
     "react-final-form": "3.1.3",
-    "react-final-form-arrays": "1.0.4",
-    "react-select": "2.0.0-alpha.7"
+    "react-final-form-arrays": "1.0.4"
   }
 }


### PR DESCRIPTION
This dep was added by mistake, it's actually provided by cozy-ui. The lockfile doesn't change since, well, the package is still there.