### PR TITLE
Confirmation modal before deleting a contact

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "cozy-client": "1.0.0-beta.1",
     "cozy-scripts": "0.5.5",
     "cozy-stack-link": "1.0.0-beta.1",
-    "cozy-ui": "7.9.0",
+    "cozy-ui": "7.10.0",
     "final-form": "4.2.1",
     "final-form-arrays": "1.0.4",
     "lodash": "4.17.5",

--- a/src/components/ContactCard/__snapshots__/ContactCard.spec.jsx.snap
+++ b/src/components/ContactCard/__snapshots__/ContactCard.spec.jsx.snap
@@ -93,7 +93,7 @@ exports[`ContactCard should match snapshot 1`] = `
               className="select-control__input"
             >
               <div
-                className="react-select__value-container react-select__value-container--isMulti css-6rkci4"
+                className="react-select__value-container react-select__value-container--isMulti css-12sevwg"
               >
                 <div
                   className="react-select__placeholder css-16ucli7"
@@ -113,12 +113,12 @@ exports[`ContactCard should match snapshot 1`] = `
                 className="react-select__indicators css-1lfa1d8"
               >
                 <span
-                  className="react-select__indicator-separator css-1cnd6ox"
+                  className="react-select__indicator-separator css-1hq2z0s"
                   css={undefined}
                   role="presentation"
                 />
                 <div
-                  className="react-select__indicator react-select__dropdown-indicator css-1c0gw5t"
+                  className="react-select__indicator react-select__dropdown-indicator css-1k2060c"
                   css={undefined}
                   onMouseDown={[Function]}
                   onTouchEnd={[Function]}

--- a/src/components/ContactsApp.jsx
+++ b/src/components/ContactsApp.jsx
@@ -8,8 +8,9 @@ import OpenContactFormButton from "./Buttons/OpenContactFormButton";
 import ContactsIntentButton from "./Buttons/ContactsIntentButton";
 import ContactCardModal from "./Modals/ContactCardModal";
 import ContactFormModal from "./Modals/ContactFormModal";
-import { SelectionBar } from "cozy-ui/react";
+import { SelectionBar, Alerter } from "cozy-ui/react";
 import { withContacts, withDeletion } from "../connections/allContacts";
+import { getFullContactName } from "../helpers/contacts";
 
 const ContactsHeaderWithActions = ({ displayContactForm }, { t }) => (
   <ContactsHeader
@@ -66,6 +67,11 @@ class ContactsApp extends React.Component {
     this.setState({
       displayedContact: contact
     });
+  };
+
+  onDeleteContact = contact => {
+    this.hideContactCard();
+    Alerter.info("deleted", { name: getFullContactName(contact.name) });
   };
 
   hideContactCard = () => {
@@ -140,7 +146,7 @@ class ContactsApp extends React.Component {
           <ContactCardModal
             onClose={this.hideContactCard}
             contact={displayedContact}
-            onDeleteContact={this.hideContactCard}
+            onDeleteContact={this.onDeleteContact}
           />
         )}
         {isCreationFormDisplayed && (
@@ -150,6 +156,7 @@ class ContactsApp extends React.Component {
             onCreateContact={this.onCreateContact}
           />
         )}
+        <Alerter t={t} />
       </main>
     );
   }

--- a/src/components/Modals/ContactCardModal.jsx
+++ b/src/components/Modals/ContactCardModal.jsx
@@ -79,12 +79,12 @@ class ContactCardModal extends React.Component {
         {showConfirmDeleteModal && (
           <Modal
             into="body"
-            title="Supprimer ce contact ?"
-            description="Apu contact"
-            primaryText="ouais"
+            title={t("delete-confirmation.title")}
+            description={t("delete-confirmation.description")}
+            primaryText={t("delete")}
             primaryType="danger"
             primaryAction={this.deleteContact}
-            secondaryText="en fait non"
+            secondaryText={t("cancel")}
             secondaryAction={this.toggleConfirmDeleteModal}
             dismissAction={this.toggleConfirmDeleteModal}
           />

--- a/src/components/Modals/ContactCardModal.jsx
+++ b/src/components/Modals/ContactCardModal.jsx
@@ -35,29 +35,64 @@ ContactCardMenu.propTypes = {
   }).isRequired
 };
 
-const ContactCardModal = (
-  { onClose, contact, deleteContact, onDeleteContact },
-  { t }
-) => (
-  <Modal into="body" dismissAction={onClose} size="xlarge">
-    <ContactCard
-      title={t("contact_info")}
-      contact={contact}
-      renderHeader={children => (
-        <ModalHeader className="contact-card-modal__header">
-          {children}
-          <ContactCardMenu
-            deleteAction={{
-              label: t("delete"),
-              action: () => deleteContact(contact).then(() => onDeleteContact())
-            }}
+class ContactCardModal extends React.Component {
+  state = {
+    showConfirmDeleteModal: false
+  };
+
+  toggleConfirmDeleteModal = () => {
+    this.setState(state => ({
+      ...state,
+      showConfirmDeleteModal: !state.showConfirmDeleteModal
+    }));
+  };
+
+  deleteContact = async () => {
+    const { contact, deleteContact, onDeleteContact } = this.props;
+    await deleteContact(contact);
+    onDeleteContact();
+  };
+
+  render() {
+    const { onClose, contact } = this.props;
+    const { showConfirmDeleteModal } = this.state;
+    const { t } = this.context;
+
+    return (
+      <Modal into="body" dismissAction={onClose} size="xlarge">
+        <ContactCard
+          title={t("contact_info")}
+          contact={contact}
+          renderHeader={children => (
+            <ModalHeader className="contact-card-modal__header">
+              {children}
+              <ContactCardMenu
+                deleteAction={{
+                  label: t("delete"),
+                  action: this.toggleConfirmDeleteModal
+                }}
+              />
+            </ModalHeader>
+          )}
+          renderBody={children => <ModalContent>{children}</ModalContent>}
+        />
+        {showConfirmDeleteModal && (
+          <Modal
+            into="body"
+            title="Supprimer ce contact ?"
+            description="Apu contact"
+            primaryText="ouais"
+            primaryType="danger"
+            primaryAction={this.deleteContact}
+            secondaryText="en fait non"
+            secondaryAction={this.toggleConfirmDeleteModal}
           />
-        </ModalHeader>
-      )}
-      renderBody={children => <ModalContent>{children}</ModalContent>}
-    />
-  </Modal>
-);
+        )}
+      </Modal>
+    );
+  }
+}
+
 ContactCardModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   contact: PropTypes.shape({

--- a/src/components/Modals/ContactCardModal.jsx
+++ b/src/components/Modals/ContactCardModal.jsx
@@ -37,13 +37,13 @@ ContactCardMenu.propTypes = {
 
 class ContactCardModal extends React.Component {
   state = {
-    showConfirmDeleteModal: false
+    shouldDisplayConfirmDeleteModal: false
   };
 
   toggleConfirmDeleteModal = () => {
     this.setState(state => ({
       ...state,
-      showConfirmDeleteModal: !state.showConfirmDeleteModal
+      shouldDisplayConfirmDeleteModal: !state.shouldDisplayConfirmDeleteModal
     }));
   };
 
@@ -55,7 +55,7 @@ class ContactCardModal extends React.Component {
 
   render() {
     const { onClose, contact } = this.props;
-    const { showConfirmDeleteModal } = this.state;
+    const { shouldDisplayConfirmDeleteModal } = this.state;
     const { t } = this.context;
 
     return (
@@ -76,7 +76,7 @@ class ContactCardModal extends React.Component {
           )}
           renderBody={children => <ModalContent>{children}</ModalContent>}
         />
-        {showConfirmDeleteModal && (
+        {shouldDisplayConfirmDeleteModal && (
           <Modal
             into="body"
             title={t("delete-confirmation.title")}

--- a/src/components/Modals/ContactCardModal.jsx
+++ b/src/components/Modals/ContactCardModal.jsx
@@ -50,7 +50,7 @@ class ContactCardModal extends React.Component {
   deleteContact = async () => {
     const { contact, deleteContact, onDeleteContact } = this.props;
     await deleteContact(contact);
-    onDeleteContact();
+    onDeleteContact(contact);
   };
 
   render() {
@@ -86,6 +86,7 @@ class ContactCardModal extends React.Component {
             primaryAction={this.deleteContact}
             secondaryText="en fait non"
             secondaryAction={this.toggleConfirmDeleteModal}
+            dismissAction={this.toggleConfirmDeleteModal}
           />
         )}
       </Modal>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
   "confirm": "Confirm",
   "save": "Save",
   "delete": "Delete",
+  "deleted": "The contact %{name} has been deleted.",
   "selected_contacts":
     "%{smart_count} selected contact |||| %{smart_count} selected contacts",
   "contact_info": "Contact informations",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,6 @@
   "confirm": "Confirm",
   "save": "Save",
   "delete": "Delete",
-  "deleted": "The contact %{name} has been deleted.",
   "selected_contacts":
     "%{smart_count} selected contact |||| %{smart_count} selected contacts",
   "contact_info": "Contact informations",
@@ -40,5 +39,11 @@
   "groups": {
     "none": "There are no existing groups yet.",
     "manage": "Manage groups"
+  },
+  "delete-confirmation": {
+    "deleted": "The contact %{name} has been deleted.",
+    "title": "Delete this contact?",
+    "description":
+      "This contact will also be deleted from your Google address book"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,9 +1879,9 @@ cozy-stack-link@1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/cozy-stack-link/-/cozy-stack-link-1.0.0-beta.1.tgz#9005812afec111f46a95ef8ac2078ff5303fa175"
 
-cozy-ui@7.9.0:
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-7.9.0.tgz#458927d8309642643a8ae97cfb7f0912b225b6fd"
+cozy-ui@7.10.0:
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-7.10.0.tgz#08ee15c108f1f85d40d10a678516a71508454a53"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"


### PR DESCRIPTION
The `ModalCard` is now a class with a state, to decide whether the confirmation modal is open or not. And after the deletion, we show an alert message. The changes are pretty straightforward!

Just waiting on the cozy-ui release.