### PR TITLE
feat: Import vcard

### DIFF
--- a/src/components/ContactImportationModal/ContactImportationCard/ContactImportationFile.jsx
+++ b/src/components/ContactImportationModal/ContactImportationCard/ContactImportationFile.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Icon } from "cozy-ui/react";
+import palette from "cozy-ui/stylus/settings/palette.json";
 import IconFileVcf from "../../../assets/icons/file-vcf.svg";
 import IconFileWrongFormat from "../../../assets/icons/file-wrong-format.svg";
 import IconFilePartialImport from "../../../assets/icons/file-partial-import.svg";
@@ -34,8 +35,16 @@ export default function ImportationFile({ status, name, unselectAction }) {
         <span className="importation-file-name">
           {name}
           {UNSELECTABLE_FILE_STATUS_SET.has(status) && (
-            <button className="importation-file-oval" onClick={unselectAction}>
-              <Icon className="importation-file-cross" icon={IconCross} />
+            <button
+              className="importation-file-oval"
+              onClick={e => unselectAction(e)}
+            >
+              <Icon
+                icon={IconCross}
+                color={palette["coolGrey"]}
+                width="10"
+                height="10"
+              />
             </button>
           )}
         </span>

--- a/src/components/ContactsList/ContactsEmptyList.jsx
+++ b/src/components/ContactsList/ContactsEmptyList.jsx
@@ -19,6 +19,7 @@ export default class ContactsEmptyList extends React.Component {
 
   componentWillMount() {
     // cozy-client-js is needed for intents
+    // we should refactor to not duplicate initialization code (see src/targets/browser/index.jsx)
     const root = document.querySelector("[role=application]");
     const data = root.dataset;
     cozy.client.init({

--- a/src/components/ContactsList/ContactsEmptyList.jsx
+++ b/src/components/ContactsList/ContactsEmptyList.jsx
@@ -9,6 +9,9 @@ import palette from "cozy-ui/stylus/settings/palette.json";
 
 const IconTeam = "upload";
 
+const vcardEnabled =
+  new URL(window.location).searchParams.get("enablevcardimport") !== null;
+
 export default class ContactsEmptyList extends React.Component {
   state = {
     hasConnector: false
@@ -57,7 +60,7 @@ export default class ContactsEmptyList extends React.Component {
                 />
               </IntentOpener>
             </span>
-            {false && (
+            {vcardEnabled && (
               <span className="contacts-empty-action">
                 <Button
                   className="contacts-empty-button"

--- a/src/importation/__fixtures__/datapoints.vcf
+++ b/src/importation/__fixtures__/datapoints.vcf
@@ -1,0 +1,13 @@
+BEGIN:VCARD
+VERSION:3.0
+FN:Jean Neige
+N:Neige;Jean;;;
+EMAIL;TYPE=INTERNET;TYPE=WORK:jean@cozy.tools
+EMAIL;TYPE=INTERNET;TYPE=HOME:neige@cozy.tools
+item1.EMAIL;TYPE=INTERNET:jean.neige@cozy.tools
+item1.X-ABLabel:complet
+TEL;TYPE=WORK:0123456789
+TEL;TYPE=CELL:0987654321
+item2.TEL:9999999999
+item2.X-ABLabel:complet
+END:VCARD

--- a/src/importation/vcard.spec.js
+++ b/src/importation/vcard.spec.js
@@ -99,5 +99,25 @@ describe("importation/vcard", () => {
         ]
       });
     });
+
+    test("import datapoints label", async () => {
+      const contacts = [];
+      const data = fixture.data("datapoints.vcf");
+      const report = await vcard.importData(data, {
+        save: c => contacts.push(c)
+      });
+      expect(report).toMatchObject({
+        total: 1,
+        imported: 1
+      });
+      expect(contacts[0].email).toContainEqual({
+        address: "jean.neige@cozy.tools",
+        type: "complet"
+      });
+      expect(contacts[0].phone).toContainEqual({
+        number: "9999999999",
+        type: "complet"
+      });
+    });
   });
 });

--- a/src/importation/vcard.spec.js
+++ b/src/importation/vcard.spec.js
@@ -6,7 +6,7 @@ import v2to3 from "./v2to3";
 
 describe("importation/vcard", () => {
   const savedContacts = [];
-  const save = async contact => savedContacts.push(contact);
+  const save = contact => savedContacts.push(contact);
 
   beforeEach(() => {
     savedContacts.length = 0;


### PR DESCRIPTION
The feature is still disabled by default, but can now be enabled with a query parameter: `enablevcardimport`: http://contacts-dev.cozy.tools:8080/?enablevcardimport

_note: Because react-router is used, the query parameters must be located just after the TLD: http://contacts-dev.cozy.tools:8080/?enablevcardimport#/folder_

This PR tries to fix or expose some feature:

- UI: Center the icon in the button (cf. https://github.com/cozy/cozy-ui/issues/554) https://github.com/cozy/cozy-contacts/pull/206/commits/690c17b56db0fb605dd224b684f1799e3ff09f69
- feat: Enable the feature with url query parameter enablevcardimport https://github.com/cozy/cozy-contacts/pull/206/commits/63fe72bf26609f9f2673ffae19ae60d5f8575295
- test: Check import of label datapoints that checks if labels in `*.vcf` are imported.

Feel free to drive me to some needed changes.

_note: With `cozy/cozy-guidelines` for commits messages, the PR description is superfluos._