### PR TITLE
fix: Unfreeze the application when selecting a contact

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -17,7 +17,8 @@ class ContactsApp extends React.Component {
   state = {
     displayedContact: null,
     isImportationDisplayed: false,
-    isCreationFormDisplayed: false
+    isCreationFormDisplayed: false,
+    isDisplayedContactUpdated: false
   }
 
   displayImportation = () => {
@@ -34,7 +35,8 @@ class ContactsApp extends React.Component {
 
   displayContactCard = contact => {
     this.setState({
-      displayedContact: contact
+      displayedContact: contact,
+      isDisplayedContactUpdated: false
     })
   }
 
@@ -47,7 +49,8 @@ class ContactsApp extends React.Component {
 
   hideContactCard = () => {
     this.setState({
-      displayedContact: null
+      displayedContact: null,
+      isDisplayedContactUpdated: false
     })
   }
 
@@ -69,9 +72,10 @@ class ContactsApp extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.state.displayedContact) {
+    if (this.state.displayedContact && !this.state.isDisplayedContactUpdated) {
       this.setState(state => ({
         ...state,
+        isDisplayedContactUpdated: true,
         displayedContact: prevProps.contacts.find(
           contact => contact._id === state.displayedContact._id
         )


### PR DESCRIPTION
We decided to use `componentWillReceiveProps` to synchronize unsynchronized data.
See https://github.com/cozy/cozy-contacts/pull/87/files\#diff-b5b123b65f648395a7716fa02882b0b0R103

But with the migration to React 16, this function became deprecated, we decided to use
`componentDidUpdate`. See https://github.com/cozy/cozy-contacts/pull/215/\#discussion_r208131374

In the application, the state (the contacts array) is not under the responsibility of the
application but the library `cozy-client`. If we need to delete an item of this array
we call the library and the props of the application changed and the render is called to
update the UI. But if we want to change a property of an item, the modal did not get the change
because we duplicate the item: one copy is passed as props to the modal, the original stay
in the contacts array. That is a smell and we should not multiply source of truth because
it will lead to desynchronization, sooner or later.
`setState` in `componentDidUpdate` could cause a infinite loop of rendering.

As a quick fix, we commit these changes, but we need to review the whole architecture to
not have to duplicate data to avoid desynchronisation.