### PR TITLE
fix: Prevent toolbar from shrinking

### DIFF
--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -17,6 +17,7 @@
     max-width 80rem
     margin .75rem auto
     display flex
+    flex 0 0 auto
 
     .topbar__left
         flex 1


### PR DESCRIPTION
On small-ish screens, the toolbar would shrink and the list goes on top of the toolbar. This prevents the bar from shrinking below it's natural height.