### PR TITLE
chore: Use cozy-app renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
-  "extends": ["config:base"],
+  "extends": ["cozy-app"],
   "pinVersions": true,
   "schedule": ["after 9pm and before 6am on every weekday", "every weekend"],
-  "timezone": "Europe/Paris",
   "devDependencies": {
     "automerge": true
   }


### PR DESCRIPTION
We now have a shareable config for renovate — this repo is volunteering to be the test dummy.