### PR TITLE
fix: Error when creating a new contact if contacts list is emty

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -75,7 +75,11 @@ class ContactsApp extends React.Component {
       const displayedContact = this.props.contacts.find(
         contact => contact._id === this.state.displayedContact._id
       )
-      if (displayedContact._rev !== previouslyDisplayedContact._rev) {
+      if (
+        displayedContact &&
+        previouslyDisplayedContact &&
+        displayedContact._rev !== previouslyDisplayedContact._rev
+      ) {
         this.setState(state => ({
           ...state,
           displayedContact: displayedContact


### PR DESCRIPTION
If we launch the app without importing data, when we create our first contact, we had 2 errors


