### PR TITLE
Get app slug from stack

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -34,5 +34,6 @@
   data-cozy-locale="{{.Locale}}"
   data-cozy-app-name="{{.AppName}}"
   data-cozy-app-editor="{{.AppEditor}}"
+  data-cozy-app-slug="{{.AppSlug}}"
   data-cozy-icon-path="{{.IconPath}}"
 >

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -26,4 +26,5 @@
   data-cozy-token="{{.Token}}"
   data-cozy-domain="{{.Domain}}"
   data-cozy-locale="{{.Locale}}"
+  data-cozy-app-slug="{{.AppSlug}}"
 >


### PR DESCRIPTION
Necessary to use the new cozy-bar navigation
and the home app detection


