### PR TITLE
fix: Don't crash if contact doesn't have some info

### DIFF
--- a/src/components/ContactCard/ContactIdentity.spec.jsx
+++ b/src/components/ContactCard/ContactIdentity.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import ContactIdentity from './ContactIdentity'
+import AppLike from '../../tests/Applike'
+describe('ContactIdentity', () => {
+  it('should have the right informations', () => {
+    const contactWithoutName = {
+      email: [{ address: 'stephen.flinn@cirpria.me', primary: true }],
+      name: { familyName: 'Flinn', givenName: 'Stephen' },
+      groups: {
+        data: [
+          { _id: 'a', _type: 'io.cozy.contacts.groups' },
+          { _id: 'b', _type: 'io.cozy.contacts.groups' }
+        ]
+      }
+    }
+    const groupsMock = [
+      { _id: 'a', name: 'The A Team' },
+      { _id: 'b', name: 'The B Team' },
+      { _id: 'c', name: 'The C Team' }
+    ]
+
+    const app = mount(
+      <AppLike>
+        <ContactIdentity contact={contactWithoutName} groups={groupsMock} />
+      </AppLike>
+    )
+    //console.log('test', app.debug())
+    const avatar = app.find('Avatar')
+    expect(avatar.prop('text')).toEqual('SF')
+  })
+
+  it('should have the right informations even if the contact does not have a name', () => {
+    const contactWithoutName = {
+      email: [{ address: 'stephen.flinn@cirpria.me', primary: true }],
+      groups: {
+        data: [
+          { _id: 'a', _type: 'io.cozy.contacts.groups' },
+          { _id: 'b', _type: 'io.cozy.contacts.groups' }
+        ]
+      }
+    }
+    const groupsMock = [
+      { _id: 'a', name: 'The A Team' },
+      { _id: 'b', name: 'The B Team' },
+      { _id: 'c', name: 'The C Team' }
+    ]
+
+    const app = mount(
+      <AppLike>
+        <ContactIdentity contact={contactWithoutName} groups={groupsMock} />
+      </AppLike>
+    )
+    //console.log('test', app.debug())
+    const avatar = app.find('Avatar')
+    expect(avatar.prop('text')).toEqual('')
+  })
+})

--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -55,14 +55,24 @@ export const makeValuesArray = fields =>
     values: Array.isArray(field.values) ? field.values : [field.values]
   }))
 
-export const getInitials = name =>
-  ['givenName', 'familyName']
+export const getInitials = name => {
+  if (!name) return ''
+  return ['givenName', 'familyName']
     .map(part => name[part] || '')
     .map(name => name[0])
     .join('')
+}
 
-export const getFullContactName = name =>
-  ['namePrefix', 'givenName', 'additionalName', 'familyName', 'nameSuffix']
+export const getFullContactName = name => {
+  if (!name) return ''
+  return [
+    'namePrefix',
+    'givenName',
+    'additionalName',
+    'familyName',
+    'nameSuffix'
+  ]
     .map(part => name[part])
     .join(' ')
     .trim()
+}


### PR DESCRIPTION
If contact didn't have a `name` then the app crashed. 