### PR TITLE
feat: Add flags feature

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -13,13 +13,20 @@ import Toolbar from './Toolbar'
 import ContactsSelectionBar from './layout/ContactsSelectionBar'
 import { ModalManager } from '../helpers/modalManager'
 import SpinnerContact from './Components/Spinner'
+import flag, { FlagSwitcher } from 'cozy-flags'
+import initFlags from '../helpers/flags'
 
 class ContactsApp extends React.Component {
+  componentWillMount() {
+    initFlags()
+  }
+
   render() {
     const { groups, t } = this.props
     return (
       <Layout monocolumn="true">
         <Main>
+          {flag('switcher') && <FlagSwitcher />}
           <ContactsSelectionBar trashAction={this.props.deleteContact} />
           <Header right={<Toolbar groups={this.props.groups} />} />
           <Content>

--- a/src/components/ContactGroups/ContactGroupManager.jsx
+++ b/src/components/ContactGroups/ContactGroupManager.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import flag from 'cozy-flags'
 
 import { Button } from 'cozy-ui/transpiled/react'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
@@ -76,10 +77,12 @@ const MenuWithFixedComponent = props => {
   return (
     <components.Menu {...props}>
       {children}
-      <ContactGroupCreation
-        createGroup={createGroup}
-        toggleMenuIsOpen={toggleMenuIsOpen}
-      />
+      {flag('groupscreation') && (
+        <ContactGroupCreation
+          createGroup={createGroup}
+          toggleMenuIsOpen={toggleMenuIsOpen}
+        />
+      )}
     </components.Menu>
   )
 }

--- a/src/helpers/flags.js
+++ b/src/helpers/flags.js
@@ -1,0 +1,20 @@
+import flag from 'cozy-flags'
+export const initFlags = () => {
+  let activateFlags = flag('switcher') === true ? true : false
+  if (process.env.NODE_ENV !== 'production' && flag('switcher') === null) {
+    activateFlags = true
+  }
+  const searchParams = new URL(window.location).searchParams
+  if (!activateFlags && searchParams.get('flags') !== null) {
+    activateFlags = true
+  }
+  if (activateFlags) {
+    flagsList()
+  }
+}
+
+const flagsList = () => {
+  flag('switcher', true)
+  flag('groupscreation')
+  flag('logs')
+}


### PR DESCRIPTION
We now have access to `cozy-flags` in `dev` mode. 

To test new feature in production, we can pass `?flags` in the url, to display the `FlagSwitcher`

We need to list our flags at the launch of the App if we want to be able to display all our flags. If we don't do that, flags will be only displayed when acceded 

I really don't like the UI :( 

<img width="313" alt="capture d ecran 2018-11-12 a 16 17 09" src="https://user-images.githubusercontent.com/1107936/48356406-79ef2a00-e696-11e8-8fea-de4c2acfc4f2.png">
