### PR TITLE
Properly delete contact groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cozy-bar": "5.0.9",
     "cozy-client": "4.7.0",
     "cozy-flags": "1.2.11",
-    "cozy-ui": "17.4.0",
+    "cozy-ui": "17.4.5",
     "cozy-vcard": "0.2.18",
     "final-form": "4.10.0",
     "final-form-arrays": "1.1.0",

--- a/src/components/ContactCard/ContactGroups.jsx
+++ b/src/components/ContactCard/ContactGroups.jsx
@@ -66,7 +66,6 @@ class ContactGroupsClass extends React.Component {
   render() {
     const { contact, allGroups } = this.props
     const userGroups = contact.groups.data
-      .filter(contactGroup => contactGroup)
       .map(userGroup => allGroups.find(group => group._id === userGroup._id))
       .filter(value => value)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3131,10 +3131,10 @@ cozy-stack-client@^4.5.0:
   dependencies:
     mime-types "2.1.20"
 
-cozy-ui@17.4.0:
-  version "17.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-17.4.0.tgz#b9c5c16443638efd247471ad92c4bf42572a668d"
-  integrity sha512-G7r/L+WBSo3B6tBK4jTRbcxGjQPIBBNRoKhHaLRnZsO+e4TLGUJP3LscEgogmg7Vndzlwaw7NkxvLvRczwmzLQ==
+cozy-ui@17.4.5:
+  version "17.4.5"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-17.4.5.tgz#4f7670bd80b8d80cb535c1794acf55bfb7ad29cb"
+  integrity sha512-xibKAWL7kD0wTheT3RlQUniFmZS+8cCVdeDoKIrZcNiAWW+7J38Kio3Px7LqOLDAXHVLO5XJs56EQeeRXhFsFA==
   dependencies:
     body-scroll-lock "^2.5.8"
     classnames "^2.2.5"


### PR DESCRIPTION
The groups where not deleted in the right field, which was causing problems.

There's still the underlying question of why groups seem to get saved in the `relationships` AND `groups` property, which I haven't investigated yet.