### PR TITLE
chore: Don't lint on pretest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
   - install -m0644 .transifexrc.tpl ~/.transifexrc
   - echo "password = $TX_PASSWD" >> ~/.transifexrc
 script:
+  - yarn lint
   - yarn test
   - yarn build
 before_deploy:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "start:browser": "cozy-scripts start --hot --browser",
     "start:mobile": "cozy-scripts start --hot --mobile",
     "deploy": "cozy-app-publish --token $REGISTRY_TOKEN --build-dir 'build/' --prepublish downcloud --postpublish mattermost",
-    "pretest": "yarn lint",
     "test": "env USE_REACT=true cozy-scripts test --verbose --coverage",
     "stack:docker": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev",
     "cozyPublish": "git fetch origin ${DEPLOY_BRANCH:-build}:${DEPLOY_BRANCH:-build} && cozy-scripts publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})"


### PR DESCRIPTION
I don't like getting yelled at because there's an extra whit space while writing tests. If I want to lint *and* test, I can do it explicitly, so I'd rather have these 2 tasks be separate.