### PR TITLE
fix: More specific styles for group names

### DIFF
--- a/src/styles/contactCard.styl
+++ b/src/styles/contactCard.styl
@@ -73,13 +73,13 @@
     margin 0
     list-style none
 
-.contact-groups-list__tag
-    display inline-block
-    background-color paleGrey
-    color slateGrey
-    font-size .9rem
-    padding .5rem
-    margin 0 .5rem
-    max-width 10rem
-    width auto
-    vertical-align middle
+    .contact-groups-list__tag
+        display inline-block
+        background-color paleGrey
+        color slateGrey
+        font-size .9rem
+        padding .5rem
+        margin 0 .5rem
+        max-width 10rem
+        width auto
+        vertical-align middle


### PR DESCRIPTION
The `elipsis` utility class was taking over these styles.