### PR TITLE
fix: Get bar during render

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -22,7 +22,6 @@ import { DOCTYPE_CONTACTS } from '../helpers/doctypes'
 import ContactsListDataLoader from './ContactsList/ContactsListDataLoader'
 import Header from './Header'
 import Toolbar from './Toolbar'
-const { BarCenter } = cozy.bar
 
 const query = client => client.all(DOCTYPE_CONTACTS)
 
@@ -33,6 +32,7 @@ class ContactsApp extends React.Component {
   }
 
   render() {
+    const { BarCenter } = cozy.bar
     const {
       t,
       breakpoints: { isMobile },


### PR DESCRIPTION
We've to be careful. When we develop, the bar is served from our node_modules and it's already imported when we init the app. 

When builded for production, bar is served by the stack and is not ready during this phase. We have to wait for the render 