### PR TITLE
feat: add select all/unselect all contacts button

### DIFF
--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import flag from 'cozy-flags'
+import { Button } from 'cozy-ui/react'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import { sortLastNameFirst, buildLastNameFirst } from './'
 import ContactsEmptyList from './ContactsEmptyList'
@@ -7,14 +10,23 @@ import ContactRow from './ContactRow'
 import ContactHeaderRow from './ContactHeaderRow'
 import withModal from '../HOCs/withModal'
 import ContactCardModal from '../Modals/ContactCardModal'
+import withSelection from '../Selection/selectionContainer'
 
 class ContactsList extends Component {
   render() {
-    const { showModal, contacts } = this.props
+    const {
+      clearSelection,
+      contacts,
+      selection,
+      showModal,
+      selectAll,
+      t
+    } = this.props
 
     if (contacts.length === 0) {
       return <ContactsEmptyList />
     } else {
+      const allContactsSelected = contacts.length === selection.length
       const sortedContacts = [...contacts].sort(sortLastNameFirst)
       const categorizedContacts = sortedContacts.reduce((acc, contact) => {
         const name = buildLastNameFirst(contact)
@@ -25,6 +37,19 @@ class ContactsList extends Component {
       }, {})
       return (
         <div className="list-wrapper">
+          {flag('select-all-contacts') && (
+            <div>
+              <Button
+                label={
+                  allContactsSelected ? t('unselect-all') : t('select-all')
+                }
+                theme="secondary"
+                onClick={() =>
+                  allContactsSelected ? clearSelection() : selectAll(contacts)
+                }
+              />
+            </div>
+          )}
           <ol className="list-contact">
             {Object.keys(categorizedContacts).map(header => (
               <li key={`cat-${header}`}>
@@ -63,4 +88,4 @@ ContactsList.propTypes = {
 }
 ContactsList.defaultProps = {}
 
-export default withModal(ContactsList)
+export default translate()(withModal(withSelection(ContactsList)))

--- a/src/components/Selection/selectionContainer.js
+++ b/src/components/Selection/selectionContainer.js
@@ -12,6 +12,13 @@ const mapDispatchToProps = dispatch => ({
     dispatch({
       type: 'SELECTION_CLEAR'
     }),
+
+  selectAll: contacts =>
+    dispatch({
+      contacts,
+      type: 'SELECT_ALL_CONTACTS'
+    }),
+
   toggleSelection: contact =>
     dispatch({
       type: 'SELECTION_TOGGLE',

--- a/src/components/Selection/selectionReducer.js
+++ b/src/components/Selection/selectionReducer.js
@@ -3,8 +3,12 @@ const initialState = {
 }
 import findIndex from 'lodash/findIndex'
 
-const selection = (state = initialState, { type, payload }) => {
+const selection = (state = initialState, { contacts, type, payload }) => {
   switch (type) {
+    case 'SELECT_ALL_CONTACTS':
+      return {
+        selection: contacts
+      }
     case 'SELECTION_CLEAR':
       return { ...initialState }
     case 'SELECTION_TOGGLE':

--- a/src/helpers/flags.js
+++ b/src/helpers/flags.js
@@ -17,4 +17,5 @@ const flagsList = () => {
   flag('switcher', true)
   flag('logs')
   flag('edit-contact')
+  flag('select-all-contacts')
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,6 +7,8 @@
   "save": "Save",
   "delete": "Delete",
   "selected_contacts": "%{smart_count} selected contact |||| %{smart_count} selected contacts",
+  "select-all": "Select all",
+  "unselect-all": "Unselect all",
   "contact_info": "Contact informations",
   "me": "me",
   "empty": {


### PR DESCRIPTION
Add a select all button that becomes a Unselect all button (this feature is hidden behind the `select-all` flag)
- UI needs to be done (according to design team proposal)
- we need to add tests for this