### PR TITLE
Feat: filter cozyMetadata from fields

### DIFF
--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -19,6 +19,7 @@ export const filterFieldList = fields =>
         '_id',
         '_rev',
         '_type',
+        'cozyMetadata',
         'id',
         'metadata',
         'relationships',


### PR DESCRIPTION
The UI is broken if we leave `cozyMetadata` in fields in `ContactCard`