### PR TITLE
feat: Flag contacts with sources as trashed

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "cozy-bar": "6.10.0",
-    "cozy-client": "6.0.0",
+    "cozy-client": "6.4.1",
     "cozy-flags": "1.2.11",
     "cozy-ui": "18.12.0",
     "cozy-vcard": "0.2.18",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -23,7 +23,18 @@ import ContactsListDataLoader from './ContactsList/ContactsListDataLoader'
 import Header from './Header'
 import Toolbar from './Toolbar'
 
-const query = client => client.all(DOCTYPE_CONTACTS)
+const query = client =>
+  client
+    .all(DOCTYPE_CONTACTS)
+    .where({
+      trashed: {
+        $exists: false
+      },
+      _id: {
+        $gt: null
+      }
+    })
+    .indexFields(['_id'])
 
 class ContactsApp extends React.Component {
   componentDidMount() {

--- a/src/components/Modals/ContactFormModal.jsx
+++ b/src/components/Modals/ContactFormModal.jsx
@@ -36,6 +36,7 @@ const ContactFormModal = ({
             const resp = await createOrUpdate(updatedContact)
             afterMutation(resp.data)
           } catch (err) {
+            console.warn(err)
             Alerter.error('error.save')
           }
         }}

--- a/src/connections/allContacts.spec.js
+++ b/src/connections/allContacts.spec.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import withContactsMutations from './allContacts'
+import AppLike from '../tests/Applike'
+
+const DummyComponent = () => <span />
+const DummyComponentWithMutations = withContactsMutations(DummyComponent)
+
+describe('Cozy Contacts API', () => {
+  let testedComponent, client
+  beforeEach(() => {
+    client = {
+      create: jest.fn(),
+      save: jest.fn(),
+      destroy: jest.fn()
+    }
+
+    const root = (
+      <AppLike>
+        <DummyComponentWithMutations client={client} />
+      </AppLike>
+    )
+    const app = shallow(root)
+    const wrappedComponent = app.find(DummyComponentWithMutations)
+    testedComponent = wrappedComponent.dive()
+  })
+
+  it('should delete a contact with no sources', () => {
+    const contact = {
+      _id: '123',
+      cozyMetadata: {
+        sync: {}
+      }
+    }
+    testedComponent.prop('deleteContact')(contact)
+    expect(client.destroy).toHaveBeenCalledWith(contact)
+
+    const contactWithoutMetadata = {
+      _id: '456'
+    }
+    testedComponent.prop('deleteContact')(contactWithoutMetadata)
+    expect(client.destroy).toHaveBeenCalledWith(contactWithoutMetadata)
+  })
+
+  it('should flag a contact with sources as trashed', () => {
+    const contact = {
+      _id: '123',
+      cozyMetadata: {
+        sync: {
+          '456': {
+            id: 'people/657623'
+          }
+        }
+      }
+    }
+    testedComponent.prop('deleteContact')(contact)
+    expect(client.destroy).not.toHaveBeenCalled()
+    expect(client.save).toHaveBeenCalledWith({
+      ...contact,
+      trashed: true
+    })
+  })
+})

--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -28,7 +28,8 @@ export const filterFieldList = fields =>
         'id',
         'metadata',
         'relationships',
-        'groups'
+        'groups',
+        'accounts'
       ].includes(field.type) === false && field.values
   )
 export const groupUnsupportedFields = (fields, supportedFieldTypes) => {

--- a/src/helpers/doctypes.js
+++ b/src/helpers/doctypes.js
@@ -1,2 +1,3 @@
 export const DOCTYPE_CONTACTS = 'io.cozy.contacts'
 export const DOCTYPE_CONTACT_GROUPS = 'io.cozy.contacts.groups'
+export const DOCTYPE_CONTACT_ACCOUNTS = 'io.cozy.contacts.accounts'

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -11,7 +11,8 @@ import configureStore from 'store/configureStore'
 import { hot } from 'react-hot-loader'
 import {
   DOCTYPE_CONTACTS,
-  DOCTYPE_CONTACT_GROUPS
+  DOCTYPE_CONTACT_GROUPS,
+  DOCTYPE_CONTACT_ACCOUNTS
 } from '../../helpers/doctypes'
 
 const RootApp = props => (
@@ -94,6 +95,10 @@ function initCozyClient(/* cozyDomain, cozyToken */) {
           groups: {
             type: 'has-many',
             doctype: DOCTYPE_CONTACT_GROUPS
+          },
+          accounts: {
+            type: 'has-many',
+            doctype: DOCTYPE_CONTACT_ACCOUNTS
           }
         }
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,20 +2656,20 @@ cozy-client-js@0.14.2:
     pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "6.4.3"
 
-cozy-client@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.0.0.tgz#a55b548ca6dc615c6f15f1035b5d32cc2b84aa41"
-  integrity sha512-n0Yz+1DZu2NjGHCoO3pR3w/t0jNpUbVKuN9akHwU2e4sOLs4+/NWY+yFALylUsauyzKEvoNzI+Tu/iEsP0i4Gw==
+cozy-client@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.4.1.tgz#218cc02232a6c4ed6eca8356bbac1c6d390f5093"
+  integrity sha512-OPByZ4O7FQb3pHnrlW7WwpXT4/hvunbBXb7jWaSNgI2V5brCFZlPuIK1b+ucNzdygZ4dCW4YprtxI3rF2A313g==
   dependencies:
     cozy-device-helper "1.6.3"
-    cozy-stack-client "^5.6.1"
+    cozy-stack-client "^6.3.3"
     lodash "4.17.11"
     prop-types "15.6.2"
     react "16.7.0"
     react-redux "5.0.7"
     redux "3.7.2"
     redux-thunk "2.3.0"
-    sift "7.0.1"
+    sift "6.0.0"
 
 cozy-device-helper@1.5.0:
   version "1.5.0"
@@ -2747,10 +2747,10 @@ cozy-scripts@1.13.0:
     webpack-dev-server "3.1.10"
     webpack-merge "4.2.1"
 
-cozy-stack-client@^5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-5.6.1.tgz#f7ea391d5a635605a16b7bdaea0a36b2d9cd1023"
-  integrity sha512-8Z1fMepAm5bu4eup4DviUux8j/bwbvuFNPVaVuk4We+k3/ly07nvp2q3sUh9YMSXGKZOsb3O9ybIZ5XzCOKnWA==
+cozy-stack-client@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.3.3.tgz#0111763fc2164518e64f27a259aaec3d9ddaf513"
+  integrity sha512-x2zZu1j+QA52jMyNFzJsB2wvaI167xJvILnt7N0Q/+YAiTH+GKKzpF3ZqO13qaeI6COdXt8maQj3myV9NQMj9A==
   dependencies:
     detect-node "2.0.4"
     mime-types "2.1.20"
@@ -9621,10 +9621,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-sift@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"
-  integrity sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==
+sift@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-6.0.0.tgz#f93a778e5cbf05a5024ebc391e6b32511a6d1f82"
+  integrity sha1-+Tp3jly/BaUCTrw5HmsyURptH4I=
 
 sigmund@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Contacts without sources are deleted right away, those with sources get a `trashed` flag and are ignored in the UI.

Two things to note:

- We need to use `_id` in the query as well, because we can't run a query only a non existing field.
- We're not using the cozy-client relationships to detect sources and instead rely on the metadata. This is because the google konnector doesn't generate the relationship at the moment. We should update this code once it's done, although it will continue to work.