### PR TITLE
Display accounts linked to the contact in the contact card

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -44,6 +44,11 @@
       "description": "Required to manage groups of contacts",
       "type": "io.cozy.contacts.groups",
       "methods": ["ALL"]
+    },
+    "contactsAccounts": {
+      "description": "Required to manage sources of contacts",
+      "type": "io.cozy.contacts.accounts",
+      "methods": ["ALL"]
     }
   },
   "intents": [

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -26,6 +26,7 @@ import Toolbar from './Toolbar'
 const query = client =>
   client
     .all(DOCTYPE_CONTACTS)
+    .include(['accounts'])
     .where({
       trashed: {
         $exists: false

--- a/src/components/ContactCard/ContactAccounts.jsx
+++ b/src/components/ContactCard/ContactAccounts.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { Text, Caption } from 'cozy-ui/transpiled/react/Text'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+
+import IconGoogle from '../../assets/icons/connect-google.svg'
+
+const ACCOUNTS_MAPPING = {
+  'konnector-google': {
+    label: 'Google',
+    icon: IconGoogle
+  }
+}
+
+const ContactAccounts = ({ accounts, t }) => (
+  <div className="contact-accounts">
+    <h3 className="contact-fields-title">
+      {t('associated_accounts', {
+        smart_count: accounts.length
+      })}
+    </h3>
+    <ol className="contact-field-list">
+      {accounts.map(account => {
+        const { icon, label } = ACCOUNTS_MAPPING[account.type]
+        return (
+          <li key={account.id}>
+            <div className="contact-field">
+              <div className="contact-field-icon">
+                <Icon icon={icon} />
+              </div>
+              <div>
+                <div className="contact-field-value">
+                  <Text>{label}</Text>
+                  <Caption>{account.name}</Caption>
+                </div>
+              </div>
+            </div>
+          </li>
+        )
+      })}
+    </ol>
+  </div>
+)
+
+ContactAccounts.propTypes = {
+  accounts: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired
+    })
+  )
+}
+
+export default translate()(ContactAccounts)

--- a/src/components/ContactCard/ContactAccounts.spec.jsx
+++ b/src/components/ContactCard/ContactAccounts.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import ContactAccounts from './ContactAccounts'
+import AppLike from '../../tests/Applike'
+
+describe('ContactAccounts component', () => {
+  it('should render a list of contact accounts', () => {
+    const props = {
+      accounts: [
+        {
+          id: '505ec401-1302-4073-b41d-aee2d0f4dcbd',
+          name: 'john.doe@gmail.com',
+          type: 'konnector-google'
+        }
+      ]
+    }
+    const tree = renderer
+      .create(
+        <AppLike>
+          <ContactAccounts {...props} />
+        </AppLike>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/ContactCard/ContactCard.jsx
+++ b/src/components/ContactCard/ContactCard.jsx
@@ -11,6 +11,7 @@ import {
   orderFieldList,
   makeValuesArray
 } from '../../helpers/contacts'
+import ContactAccounts from './ContactAccounts'
 
 const ContactCard = ({ title, contact, renderHeader, renderBody }) => {
   const fields = getFieldListFrom(contact)
@@ -25,7 +26,14 @@ const ContactCard = ({ title, contact, renderHeader, renderBody }) => {
   return (
     <div>
       {renderHeader(<ContactIdentity contact={contact} />)}
-      {renderBody(<ContactFields fields={normalizedFields} title={title} />)}
+      {renderBody(
+        <>
+          <ContactFields fields={normalizedFields} title={title} />
+          {contact.accounts.data.length > 0 ? (
+            <ContactAccounts accounts={contact.accounts.data} />
+          ) : null}
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/ContactCard/ContactCard.spec.jsx
+++ b/src/components/ContactCard/ContactCard.spec.jsx
@@ -2,7 +2,10 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import ContactCard from './ContactCard'
 import AppLike from '../../tests/Applike'
-import { DOCTYPE_CONTACT_GROUPS } from '../../helpers/doctypes'
+import {
+  DOCTYPE_CONTACT_GROUPS,
+  DOCTYPE_CONTACT_ACCOUNTS
+} from '../../helpers/doctypes'
 
 describe('ContactCard', () => {
   test('should match snapshot', () => {
@@ -28,6 +31,10 @@ describe('ContactCard', () => {
         { number: '+33 (1)9 14 02 28 31', primary: true },
         { number: '+33 (2)3 99 53 65 21', primary: false }
       ],
+      accounts: {
+        doctype: DOCTYPE_CONTACT_ACCOUNTS,
+        data: []
+      },
       groups: {
         doctype: DOCTYPE_CONTACT_GROUPS,
         data: []

--- a/src/components/ContactCard/__snapshots__/ContactAccounts.spec.jsx.snap
+++ b/src/components/ContactCard/__snapshots__/ContactAccounts.spec.jsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContactAccounts component should render a list of contact accounts 1`] = `
+<div
+  className="contact-accounts"
+>
+  <h3
+    className="contact-fields-title"
+  >
+    Account linked to this contact
+  </h3>
+  <ol
+    className="contact-field-list"
+  >
+    <li>
+      <div
+        className="contact-field"
+      >
+        <div
+          className="contact-field-icon"
+        >
+          <svg
+            className="styles__icon___23x3R"
+            height="16"
+            style={Object {}}
+            width="16"
+          >
+            <use
+              xlinkHref="#icon-0"
+            />
+          </svg>
+        </div>
+        <div>
+          <div
+            className="contact-field-value"
+          >
+            <div
+              className="styles__u-text___2UfQa"
+            >
+              Google
+            </div>
+            <div
+              className="styles__u-caption___1VRxy"
+            >
+              john.doe@gmail.com
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ol>
+</div>
+`;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "associated_accounts": "Account linked to this contact |||| Accounts linked to this contact",
   "create_contact": "Create a contact",
   "cancel": "Cancel",
   "confirm": "Confirm",

--- a/src/styles/contactCard.styl
+++ b/src/styles/contactCard.styl
@@ -83,3 +83,7 @@
         max-width 10rem
         width auto
         vertical-align middle
+
+.contact-accounts
+    .contact-field-icon
+        margin-top .2rem


### PR DESCRIPTION
In the body of the contact card, renders the sources linked to the contact if any.

We could use `ContactFields` component for this but it would require adaptation because:
- icons and field values are computed from the field type
- fields icons are "forced" in grey

Also, it seems fair to have a distinction between fields and accounts.

What do you think about it?