### PR TITLE
Fix edit contact form

### DIFF
--- a/src/components/ContactCard/ContactForm/__snapshots__/index.spec.jsx.snap
+++ b/src/components/ContactCard/ContactForm/__snapshots__/index.spec.jsx.snap
@@ -1109,8 +1109,8 @@ exports[`ContactForm should submit empty fields 1`] = `
 Object {
   "address": Array [],
   "birthday": undefined,
-  "company": undefined,
-  "cozy": undefined,
+  "company": "",
+  "cozy": "",
   "email": Array [],
   "fullname": "",
   "metadata": Object {
@@ -1121,7 +1121,7 @@ Object {
     "familyName": undefined,
     "givenName": undefined,
   },
-  "note": undefined,
+  "note": "",
   "phone": Array [],
   "relationships": Object {
     "groups": Object {

--- a/src/components/ContactCard/ContactForm/contactToFormValues.js
+++ b/src/components/ContactCard/ContactForm/contactToFormValues.js
@@ -54,8 +54,8 @@ const contactToFormValues = (contact, t) => {
         : [undefined]
 
     return {
-      givenName: name.givenName,
-      familyName: name.familyName,
+      givenName: name ? name.givenName : undefined,
+      familyName: name ? name.familyName : undefined,
       phone: phoneValue,
       email: emailValue,
       address: addressValue,

--- a/src/components/ContactCard/ContactForm/contactToFormValues.spec.js
+++ b/src/components/ContactCard/ContactForm/contactToFormValues.spec.js
@@ -74,6 +74,38 @@ describe('contactToFormValues function', () => {
     const result = contactToFormValues(contact, tSpy)
     expect(result).toEqual(expected)
   })
+
+  it('should not crash if name is undefined (contacts created via sharing)', () => {
+    const contact = {
+      id: '9ecfbf4b-20e7-4bac-87f1-eea53350857d',
+      _id: '9ecfbf4b-20e7-4bac-87f1-eea53350857d',
+      _type: 'io.cozy.contacts',
+      _rev: '1-19c313536e8b27473aa26bf105b03269',
+      address: [],
+      birthday: undefined,
+      company: undefined,
+      cozy: undefined,
+      email: undefined,
+      name: undefined,
+      note: 'Eligendi velit eos ab libero molestiae consequatur autem sed.',
+      phone: []
+    }
+    const expected = {
+      address: [undefined],
+      birthday: undefined,
+      company: undefined,
+      cozy: undefined,
+      cozyLabel: undefined,
+      email: [undefined],
+      givenName: undefined,
+      familyName: undefined,
+      note: 'Eligendi velit eos ab libero molestiae consequatur autem sed.',
+      phone: [undefined]
+    }
+
+    const result = contactToFormValues(contact, tSpy)
+    expect(result).toEqual(expected)
+  })
 })
 
 describe('moveToHead function', () => {

--- a/src/components/ContactCard/ContactForm/formValuesToContact.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.js
@@ -19,23 +19,31 @@ const formValuesToContact = data => {
       givenName,
       familyName
     },
-    email: email.filter(val => val).map(({ email, emailLabel }, index) => ({
-      address: email,
-      type: emailLabel,
-      primary: index === 0
-    })),
-    address: address
-      .filter(val => val)
-      .map(({ address, addressLabel }, index) => ({
-        formattedAddress: address,
-        type: addressLabel,
+    email: email
+      .filter(val => val && val.email)
+      .map(({ email, emailLabel }, index) => ({
+        address: email,
+        type: emailLabel,
         primary: index === 0
       })),
-    phone: phone.filter(val => val).map(({ phone, phoneLabel }, index) => ({
-      number: phone,
-      type: phoneLabel,
-      primary: index === 0
-    })),
+    address:
+      address &&
+      address
+        .filter(val => val && val.address)
+        .map(({ address, addressLabel }, index) => ({
+          formattedAddress: address,
+          type: addressLabel,
+          primary: index === 0
+        })),
+    phone:
+      phone &&
+      phone
+        .filter(val => val && val.phone)
+        .map(({ phone, phoneLabel }, index) => ({
+          number: phone,
+          type: phoneLabel,
+          primary: index === 0
+        })),
     cozy: cozy
       ? [
           {
@@ -44,10 +52,10 @@ const formValuesToContact = data => {
             primary: true
           }
         ]
-      : undefined,
-    company,
+      : '',
+    company: company || '',
     birthday,
-    note,
+    note: note || '',
     // If we don't create the relationships field manually, cozy-client doesn't create it automatically when needed
     relationships: {
       groups: {

--- a/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
@@ -70,4 +70,52 @@ describe('formValuesToContact', () => {
     const result = formValuesToContact(johnDoeFormValues)
     expect(result).toEqual(expected)
   })
+
+  it('should convert form values that have been cleared to contact', () => {
+    const formValues = {
+      address: [
+        {
+          formattedAddress: undefined,
+          primary: true,
+          type: undefined
+        }
+      ],
+      birthday: null,
+      company: undefined,
+      cozy: undefined,
+      cozyLabel: undefined,
+      email: [
+        {
+          email: undefined,
+          emailLabel: undefined
+        }
+      ],
+      familyName: 'Jane',
+      givenName: 'Doe',
+      note: undefined,
+      phone: [
+        {
+          number: undefined,
+          primary: true,
+          type: undefined
+        }
+      ]
+    }
+    const expected = {
+      fullname: 'Doe Jane',
+      name: { givenName: 'Doe', familyName: 'Jane' },
+      email: [],
+      address: [],
+      phone: [],
+      cozy: '',
+      company: '',
+      birthday: null,
+      note: '',
+      relationships: { groups: { data: [] } },
+      metadata: { version: 1, cozy: true }
+    }
+
+    const result = formValuesToContact(formValues)
+    expect(result).toEqual(expected)
+  })
 })


### PR DESCRIPTION
- fix bug when name is `undefined` (contact created via sharing)
- fix a lot of bugs when user clears values in the edit form (note, company, cozy, phone, address, email fields were not working correctly)