### PR TITLE
refactor: Use mockdate package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "4.1.0",
     "git-directory-deploy": "1.5.1",
     "identity-obj-proxy": "3.0.0",
+    "mockdate": "^2.0.2",
     "pretty-quick": "1.10.0",
     "react-dom": "16.7.0",
     "replace": "1.1.0",

--- a/src/helpers/contacts.spec.js
+++ b/src/helpers/contacts.spec.js
@@ -1,3 +1,5 @@
+import MockDate from 'mockdate'
+
 import {
   getFieldListFrom,
   filterFieldList,
@@ -8,25 +10,15 @@ import {
 } from './contacts'
 import { DOCTYPE_CONTACTS } from './doctypes'
 
-const _Date = Date
+const MOCKED_DATE = '2018-01-01T12:00:00.210Z'
 
 beforeAll(() => {
-  const DATE_TO_USE = new Date('2018-01-01T12:00:00.210Z')
-  const MockDate = (...args) => {
-    if (args.length === 0) {
-      return DATE_TO_USE
-    } else {
-      return new _Date(...args)
-    }
-  }
-  MockDate.toISOString = _Date.toISOString
-  MockDate.prototype = _Date.prototype
-  global.Date = MockDate
+  MockDate.set(MOCKED_DATE)
 })
 
 afterAll(() => {
   jest.restoreAllMocks()
-  global.Date = _Date
+  MockDate.reset()
 })
 
 describe('Manage Contacts fields', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7046,6 +7046,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
+  integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
+
 moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"


### PR DESCRIPTION
Use [mockdate](https://www.npmjs.com/package/mockdate) instead of our own functions to mock date