### PR TITLE
feat: Update cozy-client to 6.9.0 (new cozy metadata creation/update)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "cozy-bar": "6.10.0",
-    "cozy-client": "6.4.1",
+    "cozy-client": "6.9.0",
     "cozy-flags": "1.2.11",
     "cozy-ui": "18.12.0",
     "cozy-vcard": "0.2.18",

--- a/src/helpers/doctypes.js
+++ b/src/helpers/doctypes.js
@@ -1,3 +1,4 @@
 export const DOCTYPE_CONTACTS = 'io.cozy.contacts'
+export const DOCTYPE_CONTACTS_VERSION = 2
 export const DOCTYPE_CONTACT_GROUPS = 'io.cozy.contacts.groups'
 export const DOCTYPE_CONTACT_ACCOUNTS = 'io.cozy.contacts.accounts'

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -11,6 +11,7 @@ import configureStore from 'store/configureStore'
 import { hot } from 'react-hot-loader'
 import {
   DOCTYPE_CONTACTS,
+  DOCTYPE_CONTACTS_VERSION,
   DOCTYPE_CONTACT_GROUPS,
   DOCTYPE_CONTACT_ACCOUNTS
 } from '../../helpers/doctypes'
@@ -89,35 +90,14 @@ function initCozyClient(/* cozyDomain, cozyToken */) {
   return new CozyClient({
     uri: getCozyURI(),
     token: getToken(),
+    appMetadata: {
+      slug: manifest.name,
+      version: manifest.version
+    },
     schema: {
       contacts: {
         doctype: DOCTYPE_CONTACTS,
-        cozyMetadata: {
-          createdByApp: {
-            trigger: 'creation',
-            value: manifest.name
-          },
-          updatedByApps: {
-            trigger: 'update',
-            value: [manifest.name]
-          },
-          createdAt: {
-            trigger: 'creation',
-            useCurrentDate: true
-          },
-          updatedAt: {
-            trigger: 'update',
-            useCurrentDate: true
-          },
-          doctypeVersion: {
-            trigger: 'update',
-            value: 2
-          },
-          createdByAppVersion: {
-            trigger: 'update',
-            value: manifest.version
-          }
-        },
+        doctypeVersion: DOCTYPE_CONTACTS_VERSION,
         relationships: {
           groups: {
             type: 'has-many',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,13 +2656,13 @@ cozy-client-js@0.14.2:
     pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "6.4.3"
 
-cozy-client@6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.4.1.tgz#218cc02232a6c4ed6eca8356bbac1c6d390f5093"
-  integrity sha512-OPByZ4O7FQb3pHnrlW7WwpXT4/hvunbBXb7jWaSNgI2V5brCFZlPuIK1b+ucNzdygZ4dCW4YprtxI3rF2A313g==
+cozy-client@6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.9.0.tgz#e84caf6a541e68792257442e73ad2ac549374236"
+  integrity sha512-H+rEFRXKCpYDMRBccO/TsFUjRkbWOeUZy/71mXv0G+/Zk8jOn1Js2eliRaetSTYTvIleIohT/sKzRLx9xUR7uA==
   dependencies:
     cozy-device-helper "1.6.3"
-    cozy-stack-client "^6.3.3"
+    cozy-stack-client "^6.7.0"
     lodash "4.17.11"
     prop-types "15.6.2"
     react "16.7.0"
@@ -2747,13 +2747,14 @@ cozy-scripts@1.13.0:
     webpack-dev-server "3.1.10"
     webpack-merge "4.2.1"
 
-cozy-stack-client@^6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.3.3.tgz#0111763fc2164518e64f27a259aaec3d9ddaf513"
-  integrity sha512-x2zZu1j+QA52jMyNFzJsB2wvaI167xJvILnt7N0Q/+YAiTH+GKKzpF3ZqO13qaeI6COdXt8maQj3myV9NQMj9A==
+cozy-stack-client@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.7.0.tgz#cf8963b5cdbbaac92abdaeb302f723f9e3cd9612"
+  integrity sha512-OcqIQ5MEqr5vNL3AnGXceehOMLsbCcfF4Wydf39bqk9fA1LODL4dBNaExgd42A/FxwZ5dfBHarhkkfk/6EAyvw==
   dependencies:
     detect-node "2.0.4"
     mime-types "2.1.20"
+    qs "6.6.0"
 
 cozy-ui@18.12.0:
   version "18.12.0"
@@ -8609,6 +8610,11 @@ qs@6.5.2, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+qs@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
+  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
 
 query-string@^4.3.2:
   version "4.3.4"


### PR DESCRIPTION
Update `cozy-client` and change its initialization to create/update cozy metadata according to https://github.com/cozy/cozy-client/commit/bf6be9b9a9c2e10f9b2e0a3704ae1692e76f3f86