### PR TITLE
Don't display disconnected contact accounts

### DIFF
--- a/src/components/ContactCard/ContactCard.jsx
+++ b/src/components/ContactCard/ContactCard.jsx
@@ -23,14 +23,18 @@ const ContactCard = ({ title, contact, renderHeader, renderBody }) => {
   const orderedFields = orderFieldList(groupedFields, supportedFieldsInOrder)
   const normalizedFields = makeValuesArray(orderedFields)
 
+  const activeContactAccounts = contact.accounts.data.filter(
+    account => account.sourceAccount !== null
+  )
+
   return (
     <div>
       {renderHeader(<ContactIdentity contact={contact} />)}
       {renderBody(
         <>
           <ContactFields fields={normalizedFields} title={title} />
-          {contact.accounts.data.length > 0 ? (
-            <ContactAccounts accounts={contact.accounts.data} />
+          {activeContactAccounts.length > 0 ? (
+            <ContactAccounts accounts={activeContactAccounts} />
           ) : null}
         </>
       )}

--- a/src/components/ContactCard/ContactCard.spec.jsx
+++ b/src/components/ContactCard/ContactCard.spec.jsx
@@ -8,7 +8,7 @@ import {
 } from '../../helpers/doctypes'
 
 describe('ContactCard', () => {
-  test('should match snapshot', () => {
+  it('should match snapshot', () => {
     const contact = {
       _id: 'c6899688-6cc6-4ffb-82d4-ab9f9b82c582',
       _rev: '1-9368a4f2e467c449f4a1f5171a784aa8',
@@ -48,6 +48,50 @@ describe('ContactCard', () => {
         name: 'toto'
       }
     ]
+    const tree = renderer
+      .create(
+        <AppLike>
+          <ContactCard contact={contact} title="title" groups={groups} />
+        </AppLike>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should match snapshot with accounts', () => {
+    const contact = {
+      _id: 'c6899688-6cc6-4ffb-82d4-ab9f9b82c582',
+      _rev: '1-9368a4f2e467c449f4a1f5171a784aa8',
+      address: [],
+      birthday: '1998-06-03',
+      email: [{ address: 'rikki.white@celmax.name', primary: true }],
+      name: { familyName: 'White', givenName: 'Rikki' },
+      phone: [],
+      accounts: {
+        doctype: DOCTYPE_CONTACT_ACCOUNTS,
+        data: [
+          {
+            id: '8336bd7c-ea8a-4a82-8335-799a599e7ebc',
+            name: 'john.doe@gmail.com',
+            sourceAccount: '55b4b61a-6838-4219-91fa-2b846192f8aa',
+            type: 'konnector-google'
+          },
+          {
+            id: '53602dea-6e21-4613-97d6-dde4f5f4dac0',
+            name: 'john.doe+inactive@gmail.com',
+            sourceAccount: null,
+            type: 'konnector-google'
+          }
+        ]
+      },
+      groups: {
+        doctype: DOCTYPE_CONTACT_GROUPS,
+        data: []
+      },
+      unsupportedField: 'unsupportedField'
+    }
+
+    const groups = []
     const tree = renderer
       .create(
         <AppLike>

--- a/src/components/ContactCard/__snapshots__/ContactCard.spec.jsx.snap
+++ b/src/components/ContactCard/__snapshots__/ContactCard.spec.jsx.snap
@@ -240,3 +240,203 @@ exports[`ContactCard should match snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`ContactCard should match snapshot with accounts 1`] = `
+<div>
+  <div
+    className="contact-card-identity"
+  >
+    <div
+      className="styles__c-avatar___PpDI-"
+      style={
+        Object {
+          "backgroundColor": "var(--weirdGreen)",
+          "color": "white",
+        }
+      }
+    >
+      
+      <span
+        className="styles__c-avatar-initials___310qC"
+      >
+        RW
+      </span>
+    </div>
+    <div
+      className="contact-card-identity__infos"
+    >
+      <h1
+        className="contact-card-identity__title"
+      >
+        Rikki  White
+      </h1>
+      <div
+        className="spinner"
+      >
+        <div
+          className="styles__c-spinner___1snK7 styles__c-spinner--middle___RwyII styles__c-spinner--blue___1BMPR styles__c-spinner--medium___1_GL8"
+        >
+          
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <h3
+      className="contact-fields-title"
+    >
+      title
+    </h3>
+    <ol
+      className="contact-field-list"
+    >
+      <li>
+        <div
+          className="contact-field"
+        >
+          <div
+            className="contact-field-icon"
+          >
+            <svg
+              className="styles__icon___23x3R"
+              height="16"
+              style={
+                Object {
+                  "fill": "var(--coolGrey)",
+                }
+              }
+              width="16"
+            >
+              <use
+                xlinkHref="#icon-0"
+              />
+            </svg>
+          </div>
+          <div>
+            <div
+              className="contact-field-value"
+            >
+              <a
+                href="mailto:rikki.white@celmax.name"
+              >
+                rikki.white@celmax.name
+              </a>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div
+          className="contact-field"
+        >
+          <div
+            className="contact-field-icon"
+          >
+            <svg
+              className="styles__icon___23x3R"
+              height="16"
+              style={
+                Object {
+                  "fill": "var(--coolGrey)",
+                }
+              }
+              width="16"
+            >
+              <use
+                xlinkHref="#icon-0"
+              />
+            </svg>
+          </div>
+          <div>
+            <div
+              className="contact-field-value"
+            >
+              1998-6-3
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div
+          className="contact-field"
+        >
+          <div
+            className="contact-field-icon"
+          >
+            <svg
+              className="styles__icon___23x3R"
+              height="16"
+              style={
+                Object {
+                  "fill": "var(--coolGrey)",
+                }
+              }
+              width="16"
+            >
+              <use
+                xlinkHref="#icon-0"
+              />
+            </svg>
+          </div>
+          <div>
+            <div
+              className="contact-field-value"
+            >
+              unsupportedField
+            </div>
+          </div>
+        </div>
+      </li>
+    </ol>
+  </div>
+  <div
+    className="contact-accounts"
+  >
+    <h3
+      className="contact-fields-title"
+    >
+      Account linked to this contact
+    </h3>
+    <ol
+      className="contact-field-list"
+    >
+      <li>
+        <div
+          className="contact-field"
+        >
+          <div
+            className="contact-field-icon"
+          >
+            <svg
+              className="styles__icon___23x3R"
+              height="16"
+              style={Object {}}
+              width="16"
+            >
+              <use
+                xlinkHref="#icon-0"
+              />
+            </svg>
+          </div>
+          <div>
+            <div
+              className="contact-field-value"
+            >
+              <div
+                className="styles__u-text___2UfQa"
+              >
+                Google
+              </div>
+              <div
+                className="styles__u-caption___1VRxy"
+              >
+                john.doe@gmail.com
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ol>
+  </div>
+</div>
+`;


### PR DESCRIPTION
If `sourceAccount` is `null`, it means that the linked `io.cozy.accounts` has been deleted (the user disconnected the account or removed the google konnector)

See https://github.com/konnectors/cozy-konnector-google/pull/296 to see how we set `sourceAccount` to `null` on delete.