### PR TITLE
fix: Don't erase metadata.google when the contact is edited

### DIFF
--- a/src/components/ContactCard/ContactForm/formValuesToContact.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.js
@@ -1,4 +1,6 @@
-const formValuesToContact = data => {
+import get from 'lodash/get'
+
+const formValuesToContact = (data, oldContact) => {
   const {
     givenName,
     familyName,
@@ -63,6 +65,7 @@ const formValuesToContact = data => {
       }
     },
     metadata: {
+      ...get(oldContact, 'metadata', {}),
       version: 1,
       cozy: true
     }

--- a/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
@@ -67,7 +67,7 @@ describe('formValuesToContact', () => {
         }
       }
     }
-    const result = formValuesToContact(johnDoeFormValues)
+    const result = formValuesToContact(johnDoeFormValues, null)
     expect(result).toEqual(expected)
   })
 
@@ -115,7 +115,38 @@ describe('formValuesToContact', () => {
       metadata: { version: 1, cozy: true }
     }
 
-    const result = formValuesToContact(formValues)
+    const result = formValuesToContact(formValues, null)
     expect(result).toEqual(expected)
+  })
+
+  it('should not erase metadata.google if it was present in the contact', () => {
+    const oldContact = {
+      metadata: {
+        google: {
+          metadata: {
+            sources: [
+              {
+                etag: 'bb0d4f0c-ac79-4519-8873-e0445b378fd7'
+              }
+            ]
+          }
+        }
+      }
+    }
+    const expectedMetadata = {
+      cozy: true,
+      google: {
+        metadata: {
+          sources: [
+            {
+              etag: 'bb0d4f0c-ac79-4519-8873-e0445b378fd7'
+            }
+          ]
+        }
+      },
+      version: 1
+    }
+    const result = formValuesToContact(johnDoeFormValues, oldContact)
+    expect(result.metadata).toEqual(expectedMetadata)
   })
 })

--- a/src/components/ContactCard/ContactForm/index.jsx
+++ b/src/components/ContactCard/ContactForm/index.jsx
@@ -81,7 +81,7 @@ const fields = [
 const ContactForm = ({ contact, onCancel, onSubmit, t }) => (
   <Form
     mutators={{ ...arrayMutators }}
-    onSubmit={data => onSubmit(formValuesToContact(data))}
+    onSubmit={data => onSubmit(formValuesToContact(data, contact))}
     initialValues={contactToFormValues(contact, t)}
     render={({ handleSubmit }) => (
       <div>


### PR DESCRIPTION
If `metadata.google` is present in the contact, don't erase it when we edit the contact.
We need this to ensure we have an etag for contacts during sync (See: https://github.com/konnectors/cozy-konnector-google/pull/333 )