### PR TITLE
fix: cozy url is an array, not a string

### DIFF
--- a/src/components/ContactCard/ContactForm/__snapshots__/index.spec.jsx.snap
+++ b/src/components/ContactCard/ContactForm/__snapshots__/index.spec.jsx.snap
@@ -1304,7 +1304,7 @@ Object {
   "address": Array [],
   "birthday": undefined,
   "company": "",
-  "cozy": "",
+  "cozy": Array [],
   "email": Array [],
   "fullname": "",
   "metadata": Object {

--- a/src/components/ContactCard/ContactForm/formValuesToContact.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.js
@@ -54,7 +54,7 @@ const formValuesToContact = (data, oldContact) => {
             primary: true
           }
         ]
-      : '',
+      : [],
     company: company || '',
     birthday,
     note: note || '',

--- a/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
@@ -107,7 +107,7 @@ describe('formValuesToContact', () => {
       email: [],
       address: [],
       phone: [],
-      cozy: '',
+      cozy: [],
       company: '',
       birthday: null,
       note: '',


### PR DESCRIPTION
If cozy url is empty, it should be an empty array, not an empty string in contact doctype.