### PR TITLE
fix: Do the contacts accounts query only if we have contacts to migrate

### DIFF
--- a/scripts/20190429_migrateContacts.js
+++ b/scripts/20190429_migrateContacts.js
@@ -92,12 +92,12 @@ function shouldDeleteContact(contact, contactsAccounts) {
 
 async function doMigrations(dryRun, api, logWithInstance) {
   const contacts = await api.fetchAll(DOCTYPE_CONTACTS)
-  const contactsAccounts = await api.fetchAll(DOCTYPE_CONTACTS_ACCOUNT)
   if (contacts.length === 0) {
     logWithInstance('No contacts, nothing to migrate')
     return
   }
 
+  const contactsAccounts = await api.fetchAll(DOCTYPE_CONTACTS_ACCOUNT)
   const result = {
     cozy: 0,
     cozyEmpty: 0,


### PR DESCRIPTION
To avoid unnecessary queries on cozies that does not have contacts