### PR TITLE
fix(deps): Update cozy-bar to v7.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "classnames": "2.2.6",
-    "cozy-bar": "7.5.4",
+    "cozy-bar": "7.6.0",
     "cozy-client": "6.53.0",
     "cozy-flags": "1.2.11",
     "cozy-ui": "22.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3089,10 +3089,10 @@ cozy-ach@1.21.0:
     server-destroy "^1.0.1"
     timezone "^1.0.22"
 
-cozy-bar@7.5.4:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-7.5.4.tgz#74be98be9d3b993a867b7374cd05b66f5adbca1e"
-  integrity sha512-CeXFbbVCJpJ3EIujTH1VcbRuGiI3fveWmy6egqdUYn2UfH6LTGf8UzPqE5KQlXziFep9pjMRN5IPpu3vcUp5CQ==
+cozy-bar@7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-7.6.0.tgz#cfcd39229a62bbb8df9fbb6a751231620e139738"
+  integrity sha512-QqqgQmK5I6/HKWAgE60tw5LhP86vc2afRwHlGcruwhW6BA8ZU+529+7VI0pT2gMosc6iVJrfkJC4pZ8oGKxmVw==
   dependencies:
     "@babel/core" "7.5.4"
     babel-core "7.0.0-bridge.0"


### PR DESCRIPTION
The cozy-bar now bundles its own cozy-ui, which should fix the stylesheets conflicts we had between the cozy-bar's cozy-ui and app's cozy-ui.

See https://github.com/cozy/cozy-bar/pull/608 for more infos.