### PR TITLE
fix: Use the right icon

### DIFF
--- a/src/components/ContactGroups/ContactGroupManager.jsx
+++ b/src/components/ContactGroups/ContactGroupManager.jsx
@@ -93,7 +93,7 @@ const CustomOption = props => (
     withCheckbox
     actions={[
       {
-        icon: 'delete',
+        icon: 'trash',
         onClick: ({ data }) => props.selectProps.deleteGroup(data)
       }
     ]}


### PR DESCRIPTION
ATM we can't delete a created group since the icon is not there anymore 