### PR TITLE
fix: Upgrade Cozy-UI to fix visual regressions with Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-client": "13.4.2",
     "cozy-doctypes": "1.72.2",
     "cozy-flags": "1.10.0",
-    "cozy-ui": "35.1.0",
+    "cozy-ui": "35.22.0",
     "cozy-vcard": "0.2.18",
     "final-form": "4.10.0",
     "final-form-arrays": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3559,10 +3559,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@35.1.0:
-  version "35.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.1.0.tgz#df5dd3e601c8d2b73860b03e6924ee986c7ea477"
-  integrity sha512-F9husNZbFFfI6LzMi9nZpub7RyYdbsK5mQ1DPfxRRGZREF0ujNPoprIuEznKA2tG8KZYj5Ry+xZqeBh1Kxp9AA==
+cozy-ui@35.22.0:
+  version "35.22.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.22.0.tgz#ce8e1703740a27073b3cff812f9a7027d3a27e41"
+  integrity sha512-oAP+EIgS4D2J2Y7CiRNPbR9jCFrDrkiLIfpQeWkTjFbGXiCkJTdQabAx7fiZdcI0gxCo9OCv7mhtirMHv/ylKw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
Since Chrome 82 or 83, they changed the default alignment for buttons.
so we need to force it now.

See the fix in UI : https://github.com/cozy/cozy-ui/pull/1399


