### PR TITLE
Use two differents queries depends if index service was launched

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -57,7 +57,7 @@
     "triggers": {
       "description": "Used to sort contacts",
       "type": "io.cozy.triggers",
-      "verbs": ["GET"]
+      "verbs": ["GET", "POST"]
     }
   },
   "intents": [

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cozy-doctypes": "1.72.2",
     "cozy-flags": "1.10.0",
     "cozy-logger": "1.6.0",
-    "cozy-ui": "35.39.0",
+    "cozy-ui": "35.40.1",
     "cozy-vcard": "0.2.18",
     "final-form": "4.10.0",
     "final-form-arrays": "1.1.0",

--- a/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
@@ -71,8 +71,8 @@ describe('formValuesToContact', () => {
           emailLabel: undefined
         }
       ],
-      familyName: 'Jane',
-      givenName: 'Doe',
+      familyName: 'Doe',
+      givenName: 'Jane',
       note: undefined,
       phone: [
         {
@@ -87,13 +87,13 @@ describe('formValuesToContact', () => {
       birthday: null,
       company: '',
       cozy: [],
-      displayName: 'Doe Jane',
+      displayName: 'Jane Doe',
       email: [],
-      fullname: 'Doe Jane',
-      indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Janedoe' },
+      fullname: 'Jane Doe',
+      indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Doejane' },
       jobTitle: '',
       metadata: { cozy: true, version: 1 },
-      name: { familyName: 'Jane', givenName: 'Doe' },
+      name: { familyName: 'Doe', givenName: 'Jane' },
       note: '',
       phone: [],
       relationships: { groups: { data: [] } }

--- a/src/components/ContentWrapper.jsx
+++ b/src/components/ContentWrapper.jsx
@@ -1,51 +1,35 @@
 import React from 'react'
-import { DOCTYPE_CONTACTS } from '../helpers/doctypes'
-import ContactsListDataLoader from './ContactsList/ContactsListDataLoader'
+import { PropTypes } from 'prop-types'
+
+import { Content } from 'cozy-ui/transpiled/react/Layout'
+
 import Header from './Header'
 import Toolbar from './Toolbar'
-import { Content } from 'cozy-ui/transpiled/react/Layout'
-import { Query } from 'cozy-client'
+import ContactsList from './ContactsList/ContactsList.jsx'
+import SpinnerContact from './Components/Spinner'
+import fetchSortedContacts from './Hooks/fetchSortedContacts'
 
-const ContentWrapper = () => (
-  <Query
-    query={client =>
-      client
-        .all(DOCTYPE_CONTACTS)
-        .include(['accounts'])
-        .where({
-          $or: [
-            {
-              trashed: {
-                $exists: false
-              }
-            },
-            {
-              trashed: false
-            }
-          ],
-          _id: {
-            $gt: null
-          }
-        })
-        .indexFields(['_id'])
-    }
-  >
-    {({ data: contacts, fetchStatus, hasMore, fetchMore }) => {
-      return (
-        <>
-          {contacts.length >= 1 && <Header right={<Toolbar />} />}
-          <Content>
-            <ContactsListDataLoader
-              contacts={contacts}
-              fetchStatus={fetchStatus}
-              hasMore={hasMore}
-              fetchMore={fetchMore}
-            />
-          </Content>
-        </>
-      )
-    }}
-  </Query>
-)
+const ContentWrapper = ({ hasServiceBeenLaunched }) => {
+  const [hasContactsToShow, contacts] = fetchSortedContacts(
+    hasServiceBeenLaunched
+  )
+
+  if (!hasContactsToShow) {
+    return <SpinnerContact size="xxlarge" loadingType="fetching_contacts" />
+  }
+
+  return (
+    <>
+      {contacts.length >= 1 && <Header right={<Toolbar />} />}
+      <Content>
+        <ContactsList contacts={contacts} />
+      </Content>
+    </>
+  )
+}
+
+ContentWrapper.propTypes = {
+  hasServiceBeenLaunched: PropTypes.bool
+}
 
 export default ContentWrapper

--- a/src/components/ContentWrapper.spec.jsx
+++ b/src/components/ContentWrapper.spec.jsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { createMockClient, useQuery } from 'cozy-client'
+import AppLike from '../tests/Applike'
+import ContentWrapper from './ContentWrapper'
+
+const client = createMockClient({})
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+
+const contactsWithIndexes = [
+  {
+    name: { givenName: 'Jane', familyName: 'Doe' },
+    fullname: 'Jane Doe',
+    displayName: 'Jane Doe',
+    indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Doejane' }
+  }
+]
+
+const contactsWithoutIndexes = [
+  {
+    name: { givenName: 'William', familyName: 'Wallace' }
+  }
+]
+
+describe('ContentWrapper', () => {
+  it("should show a spinner if queries don't have both fetchStatus to loaded", () => {
+    const props = { hasServiceBeenLaunched: false }
+    const result = {
+      data: [{}],
+      fetchStatus: 'pending',
+      hasMore: false,
+      fetchMore: jest.fn()
+    }
+    useQuery.mockReturnValue(result)
+
+    const jsx = (
+      <AppLike client={client}>
+        <ContentWrapper {...props} />
+      </AppLike>
+    )
+    const { getByTestId } = render(jsx)
+    expect(getByTestId('contactSpinner'))
+  })
+
+  it('should show a spinner if queries are both loaded but still with more data to fetch', () => {
+    const props = { hasServiceBeenLaunched: false }
+    const result = {
+      data: [{}],
+      fetchStatus: 'loaded',
+      hasMore: true,
+      fetchMore: jest.fn()
+    }
+    useQuery.mockReturnValue(result)
+
+    const jsx = (
+      <AppLike client={client}>
+        <ContentWrapper {...props} />
+      </AppLike>
+    )
+    const { getByTestId } = render(jsx)
+    expect(getByTestId('contactSpinner'))
+  })
+
+  it('should have empty section (for contacts without indexes) if service has been launched', () => {
+    const props = { hasServiceBeenLaunched: true }
+    const valueForContactsWithIndexes = {
+      data: contactsWithIndexes,
+      fetchStatus: 'loaded',
+      hasMore: false,
+      fetchMore: jest.fn()
+    }
+    const valueForContactsWithoutIndexes = {
+      data: contactsWithoutIndexes,
+      fetchStatus: 'loaded',
+      hasMore: false,
+      fetchMore: jest.fn()
+    }
+
+    useQuery
+      .mockReturnValue(valueForContactsWithoutIndexes)
+      .mockReturnValueOnce(valueForContactsWithIndexes)
+
+    const jsx = (
+      <AppLike client={client}>
+        <ContentWrapper {...props} />
+      </AppLike>
+    )
+    const { getByText } = render(jsx)
+    expect(getByText('EMPTY'))
+  })
+
+  it('should not have empty section (for contacts without indexes) if service has not been launched', () => {
+    const props = { hasServiceBeenLaunched: false }
+    const valueForContactsWithIndexes = {
+      data: contactsWithIndexes,
+      fetchStatus: 'loaded',
+      hasMore: false,
+      fetchMore: jest.fn()
+    }
+    const valueForContactsWithoutIndexes = {
+      data: contactsWithoutIndexes,
+      fetchStatus: 'loaded',
+      hasMore: false,
+      fetchMore: jest.fn()
+    }
+
+    useQuery
+      .mockReturnValue(valueForContactsWithoutIndexes)
+      .mockReturnValueOnce(valueForContactsWithIndexes)
+
+    const jsx = (
+      <AppLike client={client}>
+        <ContentWrapper {...props} />
+      </AppLike>
+    )
+    const { queryByText } = render(jsx)
+    expect(queryByText('EMPTY')).toBeNull()
+  })
+})

--- a/src/components/Hooks/fetchSortedContacts.js
+++ b/src/components/Hooks/fetchSortedContacts.js
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+
+import useFetchContacts from './useFetchContacts'
+import { harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl } from '../../helpers/contacts'
+import {
+  contactsByFamilyNameGivenNameEmailCozyUrl,
+  contactsWithoutIndexes
+} from '../../helpers/queries'
+
+/**
+ * Fetches and harmonize contacts
+ * @param {bool} hasServiceBeenLaunched - keepIndexFullNameAndDisplayNameUpToDate service launch status
+ * @returns {array} [hasContactsToShow, contacts]
+ */
+const fetchSortedContacts = hasServiceBeenLaunched => {
+  const [isContactsWithIndexesFinished, contactsWithIndexes] = useFetchContacts(
+    contactsByFamilyNameGivenNameEmailCozyUrl
+  )
+  const [
+    isContactsWithNoIndexesFinished,
+    contactsWithNoIndexes
+  ] = useFetchContacts(contactsWithoutIndexes)
+
+  const [hasAlreadySortedContacts, setHasAlreadySortedContacts] = useState(
+    false
+  )
+  const [sortedContacts, setSortedContacts] = useState([])
+
+  const fetchesAreFinished =
+    isContactsWithIndexesFinished && isContactsWithNoIndexesFinished
+
+  if (!fetchesAreFinished) {
+    return [false, sortedContacts]
+  }
+
+  if (fetchesAreFinished && !hasAlreadySortedContacts) {
+    const reworkedContacts = hasServiceBeenLaunched
+      ? contactsWithIndexes.concat(contactsWithNoIndexes)
+      : harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl(
+          contactsWithIndexes,
+          contactsWithNoIndexes
+        )
+
+    setHasAlreadySortedContacts(true)
+    setSortedContacts(reworkedContacts)
+  }
+
+  return [true, sortedContacts]
+}
+
+export default fetchSortedContacts

--- a/src/components/Hooks/useFetchContacts.js
+++ b/src/components/Hooks/useFetchContacts.js
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import { useQuery } from 'cozy-client'
+
+/**
+ * Hook to fetch contacts according to a query.
+ * FetchMore is triggered as many as necessary to get all contacts
+ * @param {object} query - Definition created with Q()
+ * @returns {array} Query's status {bool} and contacts {array}
+ */
+const useFetchContacts = query => {
+  const [isFetchFinished, setIsFetchFinished] = useState(false)
+  const [contacts, setContacts] = useState([])
+  const { data, fetchStatus, hasMore, fetchMore } = useQuery(
+    query.definition,
+    query.options
+  )
+
+  if (fetchStatus === 'loaded' && !hasMore) {
+    if (isFetchFinished) return [isFetchFinished, contacts]
+    setContacts(data)
+    setIsFetchFinished(true)
+  }
+
+  if (fetchStatus === 'loaded' && hasMore) {
+    fetchMore()
+  }
+
+  return [isFetchFinished, contacts]
+}
+
+export default useFetchContacts

--- a/src/components/Hooks/useFlags.js
+++ b/src/components/Hooks/useFlags.js
@@ -1,5 +1,13 @@
+import { useEffect } from 'react'
 import flag from 'cozy-flags'
-export const initFlags = () => {
+
+const flagsList = () => {
+  flag('switcher', true)
+  flag('logs')
+  flag('select-all-contacts')
+}
+
+const initFlags = () => {
   let activateFlags = flag('switcher') === true ? true : false
   if (process.env.NODE_ENV !== 'production' && flag('switcher') === null) {
     activateFlags = true
@@ -13,8 +21,10 @@ export const initFlags = () => {
   }
 }
 
-const flagsList = () => {
-  flag('switcher', true)
-  flag('logs')
-  flag('select-all-contacts')
+const useFlags = () => {
+  useEffect(() => {
+    initFlags()
+  }, [])
 }
+
+export default useFlags

--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -1,3 +1,4 @@
+import { sortBy } from 'lodash'
 import { models } from 'cozy-client'
 const {
   getFullname,
@@ -102,4 +103,26 @@ export const updateIndexFullNameAndDisplayName = contact => {
       )
     }
   }
+}
+
+/**
+ * Get contacts with indexes,
+ * harmonize contacts without indexes and
+ * sort them by indexes
+ * @param {array} contactsWithIndexes - contacts with indexes
+ * @param {array} contactsWithNoIndexes - contacts without indexes
+ * @returns {array} contacts with indexes and sorted
+ */
+export const harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl = (
+  contactsWithIndexes,
+  contactsWithNoIndexes
+) => {
+  const updatedContacts = contactsWithNoIndexes.map(contact =>
+    updateIndexFullNameAndDisplayName(contact)
+  )
+  const concatedContacts = contactsWithIndexes.concat(updatedContacts)
+  const sortedData = sortBy(concatedContacts, [
+    'indexes.byFamilyNameGivenNameEmailCozyUrl'
+  ])
+  return sortedData
 }

--- a/src/helpers/contacts.spec.js
+++ b/src/helpers/contacts.spec.js
@@ -2,7 +2,8 @@ import MockDate from 'mockdate'
 import {
   getConnectedAccounts,
   normalizeFields,
-  updateIndexFullNameAndDisplayName
+  updateIndexFullNameAndDisplayName,
+  harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl
 } from './contacts'
 import { johnDoeContact } from './testData'
 
@@ -145,5 +146,75 @@ describe('updateIndexFullNameAndDisplayName', () => {
       }
     }
     expect(updateIndexFullNameAndDisplayName(johnDoeContact)).toEqual(expected)
+  })
+})
+
+describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
+  it('should returns contacts with indexes and sorted by indexes.byFamilyNameGivenNameEmailCozyUrl', () => {
+    const contactsWithIndexes = [
+      {
+        name: {
+          givenName: 'Matt',
+          familyName: 'Damon'
+        },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon'
+        }
+      },
+      {
+        name: {
+          givenName: 'John',
+          familyName: 'Doe'
+        },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'Johndoe'
+        }
+      }
+    ]
+
+    const contactsWithNoIndexes = [
+      {
+        name: {
+          givenName: 'Anton',
+          familyName: 'Bradbury'
+        }
+      },
+      {
+        name: {
+          givenName: 'William',
+          familyName: 'Wallace'
+        }
+      }
+    ]
+
+    const expected = [
+      {
+        displayName: 'Anton Bradbury',
+        fullname: 'Anton Bradbury',
+        name: { familyName: 'Bradbury', givenName: 'Anton' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Bradburyanton' }
+      },
+      {
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Johndoe' },
+        name: { familyName: 'Doe', givenName: 'John' }
+      },
+      {
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon' },
+        name: { familyName: 'Damon', givenName: 'Matt' }
+      },
+      {
+        displayName: 'William Wallace',
+        fullname: 'William Wallace',
+        name: { familyName: 'Wallace', givenName: 'William' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Wallacewilliam' }
+      }
+    ]
+
+    expect(
+      harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl(
+        contactsWithIndexes,
+        contactsWithNoIndexes
+      )
+    ).toEqual(expected)
   })
 })

--- a/src/helpers/fetches.js
+++ b/src/helpers/fetches.js
@@ -4,7 +4,7 @@ import { DOCTYPE_CONTACTS } from './doctypes'
 import { updateIndexFullNameAndDisplayName } from './contacts'
 
 /**
- * Fetch and returns a promise of contacts to update according to this :
+ * Fetches and returns a promise of contacts to update according to this :
  * The update date of the contact is more recent than the 'date'
  * @param {object} client - cozyClient
  * @param {string} date - date of comparison
@@ -50,12 +50,12 @@ export const fetchContactsToUpdate = async (client, date) => {
 }
 
 /**
- * Fetch and returns a promise of service's last success time
+ * Fetches and returns a promise of normalized service
  * @param {object} client - cozyClient
  * @param {string} serviceName - name of the service
- * @returns {promise<String>} last success time of a service
+ * @returns {promise<Object>} normalized service
  */
-export const fetchLastSuccessOfService = async (client, serviceName) => {
+export const fetchNormalizedServiceByName = async (client, serviceName) => {
   try {
     const triggersByName = await client.query(
       client.find('io.cozy.triggers', {
@@ -63,12 +63,12 @@ export const fetchLastSuccessOfService = async (client, serviceName) => {
       })
     )
 
-    const trigger = await client.query(
+    const normalizedTrigger = await client.query(
       client.get('io.cozy.triggers', triggersByName.data[0].id)
     )
 
-    return trigger.data.current_state.last_success
+    return normalizedTrigger.data
   } catch (e) {
-    throw new Error(`Can't find last exectution of ${serviceName} : ${e}`)
+    throw new Error(`Can't find ${serviceName} : ${e}`)
   }
 }

--- a/src/helpers/fetches.spec.js
+++ b/src/helpers/fetches.spec.js
@@ -1,4 +1,4 @@
-import { fetchContactsToUpdate, fetchLastSuccessOfService } from './fetches'
+import { fetchContactsToUpdate, fetchNormalizedServiceByName } from './fetches'
 import { updateIndexFullNameAndDisplayName } from './contacts'
 import { johnDoeContact } from './testData'
 
@@ -18,17 +18,18 @@ describe('fetchContactsToUpdate', () => {
   })
 })
 
-describe('fetchLastSuccessOfService', () => {
-  it('should fetch the latest execution date', async () => {
-    const triggersResult = {
+describe('fetchNormalizedServiceByName', () => {
+  it('should fetch a normalized service', async () => {
+    const trigger = {
       data: [
         {
           id: '6e0847f496cbeb11e3ed653f170086bd'
         }
       ]
     }
-    const trigger = {
+    const normalizedTrigger = {
       data: {
+        id: '6e0847f496cbeb11e3ed653f170086bd',
         current_state: {
           last_success: '2020-08-12T11:14:46.060006+02:00'
         }
@@ -37,11 +38,14 @@ describe('fetchLastSuccessOfService', () => {
 
     client.query = jest
       .fn()
-      .mockReturnValueOnce(triggersResult)
       .mockReturnValueOnce(trigger)
+      .mockReturnValueOnce(normalizedTrigger)
 
-    const expected = '2020-08-12T11:14:46.060006+02:00'
-    expect(await fetchLastSuccessOfService(client, 'serviceName')).toMatch(
+    const expected = {
+      id: '6e0847f496cbeb11e3ed653f170086bd',
+      current_state: { last_success: '2020-08-12T11:14:46.060006+02:00' }
+    }
+    expect(await fetchNormalizedServiceByName(client, 'serviceName')).toEqual(
       expected
     )
   })

--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -32,3 +32,46 @@ export const queryAllGroups = {
     fetchPolicy: olderThan30sec
   }
 }
+
+export const contactsByFamilyNameGivenNameEmailCozyUrl = {
+  definition: () =>
+    Q(DOCTYPE_CONTACTS)
+      .include(['accounts'])
+      .where({
+        $or: [
+          {
+            trashed: {
+              $exists: false
+            }
+          },
+          {
+            trashed: false
+          }
+        ],
+        'indexes.byFamilyNameGivenNameEmailCozyUrl': {
+          $exists: true
+        }
+      })
+      .indexFields(['indexes.byFamilyNameGivenNameEmailCozyUrl'])
+      .sortBy([{ 'indexes.byFamilyNameGivenNameEmailCozyUrl': 'asc' }])
+      .limitBy(1000),
+  options: {
+    as: 'contactsByFamilyNameGivenNameEmailCozyUrl'
+  }
+}
+
+export const contactsWithoutIndexes = {
+  definition: () =>
+    Q(DOCTYPE_CONTACTS)
+      .include(['accounts'])
+      .where({
+        'indexes.byFamilyNameGivenNameEmailCozyUrl': {
+          $exists: false
+        }
+      })
+      .indexFields(['_id'])
+      .limitBy(1000),
+  options: {
+    as: 'contactsWithoutIndexes'
+  }
+}

--- a/src/targets/services/keepIndexFullNameAndDisplayNameUpToDate.js
+++ b/src/targets/services/keepIndexFullNameAndDisplayNameUpToDate.js
@@ -3,7 +3,7 @@ import { schema } from '../../helpers/doctypes'
 import log from 'cozy-logger'
 import {
   fetchContactsToUpdate,
-  fetchLastSuccessOfService
+  fetchNormalizedServiceByName
 } from '../../helpers/fetches'
 import { updateIndexFullNameAndDisplayName } from '../../helpers/contacts'
 import { omit } from 'lodash'
@@ -12,11 +12,14 @@ export const keepIndexFullNameAndDisplayNameUpToDate = async () => {
   log('info', `Executing keepIndexFullNameAndDisplayNameUpToDate service`)
   const client = CozyClient.fromEnv(process.env, { schema })
 
-  const lastSuccess = await fetchLastSuccessOfService(
+  const normalizedService = await fetchNormalizedServiceByName(
     client,
     'keepIndexFullNameAndDisplayNameUpToDate'
   )
-  const contactsToUpdate = await fetchContactsToUpdate(client, lastSuccess)
+  const contactsToUpdate = await fetchContactsToUpdate(
+    client,
+    normalizedService.current_state.last_success
+  )
   const updatedContactsToUpload = contactsToUpdate.map(
     // omit is to prevent updateAll error : Bad special document member: _type
     // issue here : https://github.com/cozy/cozy-client/issues/758

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,9 +1325,9 @@
     type-detect "4.0.8"
 
 "@testing-library/dom@^7.17.1":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.5.tgz#178fb0bfb52540538667f2f72d4b7fb406a49499"
-  integrity sha512-qALmosaNSny/JqQ+mDhdT0N5u1a76pEcOvfWFDpBQOchtkxDm/w/bCfe0J/K7nHrwJPHelFiAZksaBs//P9fsw==
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.6.tgz#a9466c564e9cccb56175ad2ff471aa4ba43ef0b7"
+  integrity sha512-8703SWfapsEMwG10/c8AV7qK33zyy0NMDs0SbX9uEZnHWnxaNA5SnODuWS1PvFEjoNjBxfoxVZtw6uQAXO7tJw==
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@types/aria-query" "^4.2.0"
@@ -1421,9 +1421,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "16.9.46"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
-  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
+  version "16.9.47"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.47.tgz#fb092936f0b56425f874d0ff1b08051fdf70c1ba"
+  integrity sha512-dAJO4VbrjYqTUwFiQqAKjLyHHl4RSTNnRyPdX3p16MPbDKvow51wxATUPxoe2QsiXNMEYrOjc2S6s92VjG+1VQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -2960,9 +2960,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000932, caniuse-lite@^1.0.30001111:
-  version "1.0.30001117"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz#69a9fae5d480eaa9589f7641a83842ad396d17c4"
-  integrity sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==
+  version "1.0.30001118"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001118.tgz#116a9a670e5264aec895207f5e918129174c6f62"
+  integrity sha512-RNKPLojZo74a0cP7jFMidQI7nvLER40HgNfgKQEJ2PFm225L0ectUungNQoK3Xk3StQcFbpBPNEvoWD59436Hg==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -3962,10 +3962,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@35.39.0:
-  version "35.39.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.39.0.tgz#b15532a809a29f097569b2ef3ebb1991226ef646"
-  integrity sha512-4aKCB6IvDeSV/Mu2fX754UUz6P7A5t0Cqk63CD4wKigLxaNd6rhNZUFpISJy9pkqbl3lX1KgNiesryBt6+gM5g==
+cozy-ui@35.40.1:
+  version "35.40.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.40.1.tgz#b7bb7ecf2c581c56bd1aa8f85ef801a891b0f538"
+  integrity sha512-PRmOaVLHFQ6uf6nuvauG6q+p53JccGSas2Lnv3fUp8isbreM4pIhN0eVdJ+t9WF/BoOYN3tcLr75yCPXFk794w==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
@@ -4351,9 +4351,9 @@ csstype@^2.0.0, csstype@^2.5.2, csstype@^2.5.7:
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 csstype@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
-  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
+  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
 
 csswring@7.0.0:
   version "7.0.0"
@@ -4909,9 +4909,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.523:
-  version "1.3.544"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.544.tgz#ac1f7d319f6060f3d6d122261d542ec77eb1427e"
-  integrity sha512-jx6H7M1db76Q/dI3MadZC4qwNTvpiq8tdYEJswxexrIm5bH+LKRdg+VAteMF1tJJbBLrcuogE9N3nxT3Dp1gag==
+  version "1.3.548"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.548.tgz#b1bda6b24f7a1c1fa6250bb039a0bbed148f26f2"
+  integrity sha512-Xf4m3GFwCEcQ+4W45IHeZ6enPC1i+8/3aaXz8Pcd2VkNLULP0DMvoP7aKv2tQ+M/CH2SC7Qlm4S6DpzZUS2w1Q==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -5430,9 +5430,9 @@ event-stream@=3.3.4:
     through "~2.3.1"
 
 eventemitter3@^4.0.0:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.5.tgz#51d81e4f1ccc8311a04f0c20121ea824377ea6d9"
-  integrity sha512-QR0rh0YiPuxuDQ6+T9GAO/xWTExXpxIes1Nl9RykNGTnE1HJmkuEfxJH9cubjIOQZ/GH4qNBR4u8VSHaKiWs4g==
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.6.tgz#1258f6fa51b4908aadc2cd624fcd6e64f99f49d6"
+  integrity sha512-s3GJL04SQoM+gn2c14oyqxvZ3Pcq7cduSDqy3sBFXx6UPSUmgVYwQM9zwkTn9je0lrfg0gHEwR42pF3Q2dCQkQ==
 
 events@^3.0.0:
   version "3.2.0"
@@ -9064,9 +9064,9 @@ minilog@3.1.0:
   dependencies:
     microee "0.0.6"
 
-"minilog@git+https://github.com/cozy/minilog.git#master":
+"minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 
@@ -9370,9 +9370,9 @@ nock@^12.0.3:
     propagate "^2.0.0"
 
 node-abi@^2.7.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.0.tgz#11614ff22dd64dad3501074bf656e6923539e17a"
-  integrity sha512-rpKqVe24p9GvMTgtqUXdLR1WQJBGVlkYPU10qHKv9/1i9V/k04MmFLVK2WcHBf1WKKY+ZsdvARPi8F4tfJ4opA==
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
+  integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
   dependencies:
     semver "^5.4.1"
 
@@ -14355,13 +14355,13 @@ whatwg-url@^7.0.0:
     webidl-conversions "^4.0.2"
 
 whatwg-url@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.1.0.tgz#c628acdcf45b82274ce7281ee31dd3c839791771"
-  integrity sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.2.1.tgz#ed73417230784b281fb2a32c3c501738b46167c3"
+  integrity sha512-ZmVCr6nfBeaMxEHALLEGy0LszYjpJqf6PVNQUQ1qd9Et+q7Jpygd4rGGDXgHjD8e99yLFseD69msHDM4YwPZ4A==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^2.0.2"
-    webidl-conversions "^5.0.0"
+    webidl-conversions "^6.1.0"
 
 when@~3.6.x:
   version "3.6.4"


### PR DESCRIPTION
If service `keepIndexFullNameAndDisplayNameUpToDate` was already launched we want to sort contacts in a specific way. So we have to test that first, then query contacts in a way or in an other.

- Check if service was launched
- Fetches and sort contacts in two differents ways
- Refactor of fetch function to get the service