### PR TITLE
fix: Error Invalid time value for service keepIndexFullNameAndDisplayNameUpToDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ Cozy's apps use a standard set of _npm scripts_ to run common tasks, like watch,
 ### Fixtures
 
 A fixture file is available, you can import its data with :
+
 ```
 $ yarn fixtures
 ```
+
+You can also import more than 2000 contacts in one batch with this other command :
+
+```
+$ yarn fixtures:massive
+```
+
+### Services
+
+Services can be triggered (and tested manually) by running `yarn services:[ServiceName]`. You can take a look to the [cozy-konnector-dev documentation][cozy-konnector-dev] for more informations.
 
 ### Run it inside the VM
 
@@ -152,6 +163,7 @@ cozy-contacts is developed by cozy and distributed under the [AGPL v3 license][a
 [bill-doctype]: https://github.com/cozy/cozy-konnector-libs/blob/master/models/bill.js
 [konnector-doctype]: https://github.com/cozy/cozy-konnector-libs/blob/master/models/base_model.js
 [konnectors]: https://github.com/cozy/cozy-konnector-libs
+[cozy-konnector-dev]: https://github.com/konnectors/libs/tree/master/packages/cozy-jobs-cli#cozy-konnector-dev
 [agpl-3.0]: https://www.gnu.org/licenses/agpl-3.0.html
 [contribute]: CONTRIBUTING.md
 [tx]: https://www.transifex.com/cozy/

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { PropTypes } from 'prop-types'
 import flow from 'lodash/flow'
+import get from 'lodash/get'
 
 import { useClient } from 'cozy-client'
 import { Main, Layout } from 'cozy-ui/transpiled/react/Layout'
@@ -46,7 +47,7 @@ const ContactsApp = props => {
       )
       setServiceToLaunch(serviceToLaunch)
       setHasServiceBeenLaunched(
-        serviceToLaunch.current_state.last_success.length > 0
+        get(serviceToLaunch, 'current_state.last_success', '').length > 0
       )
     },
     [client]

--- a/src/helpers/fetches.js
+++ b/src/helpers/fetches.js
@@ -12,7 +12,8 @@ import { updateIndexFullNameAndDisplayName } from './contacts'
  */
 export const fetchContactsToUpdate = async (client, date) => {
   try {
-    const dateUTCForced = new Date(date).toISOString()
+    const minimumUpdateTime = date || '0000-01-01T00:00:00.00Z'
+    const dateUTCForced = new Date(minimumUpdateTime).toISOString()
     const contacts = []
 
     const queryDef = client

--- a/src/helpers/fetches.spec.js
+++ b/src/helpers/fetches.spec.js
@@ -1,8 +1,9 @@
+import CozyClient from 'cozy-client'
+
 import { fetchContactsToUpdate, fetchNormalizedServiceByName } from './fetches'
 import { updateIndexFullNameAndDisplayName } from './contacts'
 import { johnDoeContact } from './testData'
 
-import CozyClient from 'cozy-client'
 const client = new CozyClient({})
 
 describe('fetchContactsToUpdate', () => {
@@ -10,9 +11,20 @@ describe('fetchContactsToUpdate', () => {
     const lastSuccess = new Date()
     const contactToUpdate = johnDoeContact
     const contactUpToDate = updateIndexFullNameAndDisplayName(johnDoeContact)
-    client.queryAll = jest.fn(() =>
-      Promise.resolve([contactToUpdate, contactUpToDate])
-    )
+    const queryResult = [contactToUpdate, contactUpToDate]
+    client.queryAll = jest.fn().mockResolvedValue(queryResult)
+
+    const expected = [contactToUpdate]
+    expect(await fetchContactsToUpdate(client, lastSuccess)).toEqual(expected)
+  })
+
+  it('should returns contact to update even if lastSuccess is undefined', async () => {
+    const lastSuccess = undefined
+    const contactToUpdate = johnDoeContact
+    const contactUpToDate = updateIndexFullNameAndDisplayName(johnDoeContact)
+    const queryResult = [contactToUpdate, contactUpToDate]
+    client.queryAll = jest.fn().mockResolvedValue(queryResult)
+
     const expected = [contactToUpdate]
     expect(await fetchContactsToUpdate(client, lastSuccess)).toEqual(expected)
   })

--- a/src/targets/services/keepIndexFullNameAndDisplayNameUpToDate.js
+++ b/src/targets/services/keepIndexFullNameAndDisplayNameUpToDate.js
@@ -1,12 +1,13 @@
+import omit from 'lodash/omit'
 import CozyClient from 'cozy-client'
-import { schema } from '../../helpers/doctypes'
 import log from 'cozy-logger'
+
+import { schema } from '../../helpers/doctypes'
 import {
   fetchContactsToUpdate,
   fetchNormalizedServiceByName
 } from '../../helpers/fetches'
 import { updateIndexFullNameAndDisplayName } from '../../helpers/contacts'
-import { omit } from 'lodash'
 
 export const keepIndexFullNameAndDisplayNameUpToDate = async () => {
   log('info', `Executing keepIndexFullNameAndDisplayNameUpToDate service`)


### PR DESCRIPTION
- Add some documentations for Fixtures and Services
- Fix bug "Invalid time value" when accessing current_state.last_success property of a trigger

When a service was never launched, current_state.last_success is undefined