### PR TITLE
fix: Rerender ContactRow only on contact or breakpoints change

### DIFF
--- a/src/components/ContactsList/ContactRow.jsx
+++ b/src/components/ContactsList/ContactRow.jsx
@@ -7,7 +7,8 @@ import { models } from 'cozy-client'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 
 import { fullContactPropTypes } from '../ContactPropTypes'
-import withModalContainer from '../HOCs/withModal'
+import withModal from '../HOCs/withModal'
+import ContactCardModal from '../Modals/ContactCardModal'
 import ContactWithSelection from './ContactSelection'
 import ContactPhone from './Contacts/ContactPhone'
 import ContactIdentity from './Contacts/ContactIdentity'
@@ -49,7 +50,7 @@ class ContactRow extends Component {
   render() {
     const {
       contact,
-      onClick,
+      showModal,
       breakpoints: { isMobile }
     } = this.props
     const email = getPrimaryEmail(contact) || undefined
@@ -57,7 +58,14 @@ class ContactRow extends Component {
     const cozyUrl = getPrimaryCozy(contact) || undefined
 
     return (
-      <div className="contact" onClick={onClick}>
+      <div
+        className="contact"
+        onClick={() =>
+          showModal(
+            <ContactCardModal onClose={this.hideContactCard} id={contact._id} />
+          )
+        }
+      >
         <ContactWithSelection contact={contact} />
         <ContactIdentity contact={contact} />
         {!isMobile && <ContactEmail email={email} />}
@@ -70,11 +78,10 @@ class ContactRow extends Component {
 
 ContactRow.propTypes = {
   contact: fullContactPropTypes.isRequired,
-  onClick: PropTypes.func
+  showModal: PropTypes.func.isRequired
 }
 ContactRow.defaultProps = {
-  selection: null,
-  onClick: null
+  selection: null
 }
 
-export default withBreakpoints()(withModalContainer(ContactRow))
+export default withBreakpoints()(withModal(ContactRow))

--- a/src/components/ContactsList/ContactRow.jsx
+++ b/src/components/ContactsList/ContactRow.jsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import get from 'lodash/get'
+
 import { models } from 'cozy-client'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 
@@ -14,7 +16,36 @@ import ContactEmail from './Contacts/ContactEmail'
 
 const { getPrimaryCozy, getPrimaryPhone, getPrimaryEmail } = models.contact
 
+/**
+ * Returns whether a document has been updated
+ * @param {object} document - Initial document
+ * @param {object} nextDocument - Potentially modified document
+ * @returns {boolean}
+ */
+export const hasDocBeenUpdated = (document, nextDocument) =>
+  document._rev !== nextDocument._rev ||
+  get(document, 'cozyMetadata.updatedAt') !==
+    get(nextDocument, 'cozyMetadata.updatedAt')
+
 class ContactRow extends Component {
+  shouldComponentUpdate(nextProps) {
+    const { contact, ...otherProps } = this.props
+
+    const hasOtherPropsBeenChanged = Object.entries(otherProps).some(
+      ([key, otherProp]) => {
+        return otherProp !== nextProps[key]
+      }
+    )
+
+    if (
+      hasDocBeenUpdated(contact, nextProps.contact) ||
+      hasOtherPropsBeenChanged
+    ) {
+      return true
+    }
+    return false
+  }
+
   render() {
     const {
       contact,

--- a/src/components/ContactsList/ContactRow.spec.js
+++ b/src/components/ContactsList/ContactRow.spec.js
@@ -1,10 +1,10 @@
 import React from 'react'
+import renderer from 'react-test-renderer'
 import { mount } from 'enzyme'
 
 import AppLike from '../../tests/Applike'
+import ContactRow, { hasDocBeenUpdated } from './ContactRow'
 
-import ContactRow from './ContactRow'
-import renderer from 'react-test-renderer'
 describe('ContactRow', () => {
   it('should accept the strict minimum', () => {
     const contact = { email: [{ address: 'johndoe@localhost' }] }
@@ -96,5 +96,85 @@ describe('ContactRow', () => {
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('hasDocBeenUpdated', () => {
+  it('should return false if nothing changed', () => {
+    const document = {
+      contact: {
+        name: { familyName: 'Doe', givenName: 'John' },
+        _rev: '001',
+        cozyMetadata: { updatedAt: '2020' }
+      }
+    }
+    const nextDocument = {
+      contact: {
+        name: { familyName: 'Doe', givenName: 'John' },
+        _rev: '001',
+        cozyMetadata: { updatedAt: '2020' }
+      }
+    }
+    const isUpdated = hasDocBeenUpdated(document, nextDocument)
+    expect(isUpdated).toBe(false)
+  })
+
+  it('should return true if document rev changed', () => {
+    const document = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '001',
+      cozyMetadata: { updatedAt: '2020' }
+    }
+    const nextDocument = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '002',
+      cozyMetadata: { updatedAt: '2020' }
+    }
+    const isUpdated = hasDocBeenUpdated(document, nextDocument)
+    expect(isUpdated).toBe(true)
+  })
+
+  it('should return true if document updatedAt changed', () => {
+    const document = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '001',
+      cozyMetadata: { updatedAt: '2019' }
+    }
+    const nextDocument = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '001',
+      cozyMetadata: { updatedAt: '2020' }
+    }
+    const isUpdated = hasDocBeenUpdated(document, nextDocument)
+    expect(isUpdated).toBe(true)
+  })
+
+  it('should return true if document updatedAt and rev changed', () => {
+    const document = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '001',
+      cozyMetadata: { updatedAt: '2019' }
+    }
+    const nextDocument = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '002',
+      cozyMetadata: { updatedAt: '2020' }
+    }
+    const isUpdated = hasDocBeenUpdated(document, nextDocument)
+    expect(isUpdated).toBe(true)
+  })
+
+  it('should return true if document cozyMetadata is missing', () => {
+    const document = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '001'
+    }
+    const nextDocument = {
+      name: { familyName: 'Doe', givenName: 'John' },
+      _rev: '001',
+      cozyMetadata: { updatedAt: '2020' }
+    }
+    const isUpdated = hasDocBeenUpdated(document, nextDocument)
+    expect(isUpdated).toBe(true)
   })
 })

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -8,20 +8,12 @@ import { categorizeContacts } from '../../helpers/contactList'
 import ContactsEmptyList from './ContactsEmptyList'
 import ContactRow from './ContactRow'
 import ContactHeaderRow from './ContactHeaderRow'
-import withModal from '../HOCs/withModal'
-import ContactCardModal from '../Modals/ContactCardModal'
+
 import withSelection from '../Selection/selectionContainer'
 
 class ContactsList extends Component {
   render() {
-    const {
-      clearSelection,
-      contacts,
-      selection,
-      showModal,
-      selectAll,
-      t
-    } = this.props
+    const { clearSelection, contacts, selection, selectAll, t } = this.props
 
     if (contacts.length === 0) {
       return <ContactsEmptyList />
@@ -55,14 +47,6 @@ class ContactsList extends Component {
                         id={contact._id}
                         key={contact._id}
                         contact={contact}
-                        onClick={() =>
-                          showModal(
-                            <ContactCardModal
-                              onClose={this.hideContactCard}
-                              id={contact._id}
-                            />
-                          )
-                        }
                       />
                     </li>
                   ))}
@@ -77,9 +61,8 @@ class ContactsList extends Component {
   }
 }
 ContactsList.propTypes = {
-  showModal: PropTypes.func.isRequired,
   contacts: PropTypes.array.isRequired
 }
 ContactsList.defaultProps = {}
 
-export default translate()(withModal(withSelection(ContactsList)))
+export default translate()(withSelection(ContactsList))

--- a/src/components/ContactsList/__snapshots__/ContactRow.spec.js.snap
+++ b/src/components/ContactsList/__snapshots__/ContactRow.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`ContactRow should match the contact snapshot 1`] = `
 <div
   className="contact"
-  onClick={null}
+  onClick={[Function]}
 >
   <div
     className="contact-selection"


### PR DESCRIPTION
- Lines in the list are only re-rendered if there is a change of contact or breakpoints, which avoids re-rendering all lines when only one contact is changed.
- Remove useless `withModalContainer` (add props to show/hide modal) HOC on `ContactRow`

edit : will add some tests