### PR TITLE
fix: List doesn't show up if service not installed

### DIFF
--- a/src/helpers/fetches.js
+++ b/src/helpers/fetches.js
@@ -1,5 +1,6 @@
+import isEqual from 'lodash/isEqual'
 import log from 'cozy-logger'
-import { isEqual } from 'lodash'
+
 import { DOCTYPE_CONTACTS } from './doctypes'
 import { updateIndexFullNameAndDisplayName } from './contacts'
 
@@ -70,6 +71,7 @@ export const fetchNormalizedServiceByName = async (client, serviceName) => {
 
     return normalizedTrigger.data
   } catch (e) {
-    throw new Error(`Can't find ${serviceName} : ${e}`)
+    log('error', `Can't find ${serviceName} : ${e}`)
+    return null
   }
 }

--- a/src/helpers/fetches.spec.js
+++ b/src/helpers/fetches.spec.js
@@ -61,4 +61,47 @@ describe('fetchNormalizedServiceByName', () => {
       expected
     )
   })
+
+  it('should return null if no trigger found', async () => {
+    const trigger = {
+      data: []
+    }
+
+    client.query = jest.fn().mockReturnValueOnce(trigger)
+
+    expect(await fetchNormalizedServiceByName(client, 'serviceName')).toEqual(
+      null
+    )
+  })
+
+  it('should return null if query returns undefined', async () => {
+    const trigger = undefined
+
+    client.query = jest.fn().mockReturnValueOnce(trigger)
+
+    expect(await fetchNormalizedServiceByName(client, 'serviceName')).toEqual(
+      null
+    )
+  })
+
+  it('should return null if no normalized trigger found', async () => {
+    const trigger = {
+      data: [
+        {
+          id: '6e0847f496cbeb11e3ed653f170086bd'
+        }
+      ]
+    }
+
+    const normalizedTrigger = null
+
+    client.query = jest
+      .fn()
+      .mockReturnValueOnce(trigger)
+      .mockReturnValueOnce(normalizedTrigger)
+
+    expect(await fetchNormalizedServiceByName(client, 'serviceName')).toEqual(
+      null
+    )
+  })
 })


### PR DESCRIPTION
If the service was not installed, the list was not displayed and remained stuck on the spinner because of the function to retrieve the service that returned an error.

fix https://github.com/cozy/cozy-contacts/issues/682