### PR TITLE
fix: Exclude trashed contact with no indexes

### DIFF
--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -66,6 +66,16 @@ export const contactsWithoutIndexes = {
     Q(DOCTYPE_CONTACTS)
       .include(['accounts'])
       .where({
+        $or: [
+          {
+            trashed: {
+              $exists: false
+            }
+          },
+          {
+            trashed: false
+          }
+        ],
         'indexes.byFamilyNameGivenNameEmailCozyUrl': {
           $exists: false
         }


### PR DESCRIPTION
Exclude trashed contacts from the result of the query