### PR TITLE
Ajout de navigation par lettre des contacts

### DIFF
--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import flag from 'cozy-flags'
 import Button from 'cozy-ui/transpiled/react/Button'
@@ -10,35 +10,38 @@ import ContactRow from './ContactRow'
 import ContactHeaderRow from './ContactHeaderRow'
 
 import withSelection from '../Selection/selectionContainer'
+import Navigation from './Navigation/Navigation'
 
-class ContactsList extends Component {
-  render() {
-    const { clearSelection, contacts, selection, selectAll, t } = this.props
+const ContactList = ({ clearSelection, contacts, selection, selectAll, t }) => {
+  const allContactsSelected = contacts.length === selection.length
+  const categorizedContacts = useMemo(
+    () => categorizeContacts(contacts, t('empty-list')),
+    [contacts]
+  )
 
-    if (contacts.length === 0) {
-      return <ContactsEmptyList />
-    } else {
-      const allContactsSelected = contacts.length === selection.length
-      const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+  if (contacts.length === 0) {
+    return <ContactsEmptyList />
+  }
 
-      return (
-        <div className="list-wrapper">
-          {flag('select-all-contacts') && (
-            <div>
-              <Button
-                label={
-                  allContactsSelected ? t('unselect-all') : t('select-all')
-                }
-                theme="secondary"
-                onClick={() =>
-                  allContactsSelected ? clearSelection() : selectAll(contacts)
-                }
-              />
-            </div>
-          )}
-          <ol className="list-contact">
-            {Object.keys(categorizedContacts).map(header => (
-              <li key={`cat-${header}`}>
+  const letters = Object.keys(categorizedContacts)
+  return (
+    <div className="contacts-wrapper">
+      <div className="list-wrapper">
+        {flag('select-all-contacts') && (
+          <div>
+            <Button
+              label={allContactsSelected ? t('unselect-all') : t('select-all')}
+              theme="secondary"
+              onClick={() =>
+                allContactsSelected ? clearSelection() : selectAll(contacts)
+              }
+            />
+          </div>
+        )}
+        <ol className="list-contact">
+          {letters.map(header => {
+            return (
+              <li id={header} key={`cat-${header}`}>
                 <ContactHeaderRow key={header} header={header} />
                 <ol className="sublist-contact">
                   {categorizedContacts[header].map(contact => (
@@ -52,17 +55,19 @@ class ContactsList extends Component {
                   ))}
                 </ol>
               </li>
-            ))}
-          </ol>
-          <div />
-        </div>
-      )
-    }
-  }
+            )
+          })}
+        </ol>
+        <div />
+      </div>
+      <Navigation letters={letters.filter(l => l !== 'EMPTY')} />
+    </div>
+  )
 }
-ContactsList.propTypes = {
+
+ContactList.propTypes = {
   contacts: PropTypes.array.isRequired
 }
-ContactsList.defaultProps = {}
+ContactList.defaultProps = {}
 
-export default translate()(withSelection(ContactsList))
+export default translate()(withSelection(ContactList))

--- a/src/components/ContactsList/Navigation/Navigation.jsx
+++ b/src/components/ContactsList/Navigation/Navigation.jsx
@@ -1,0 +1,54 @@
+import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+
+const ANCHOR_REGEX = /#(.)$/
+
+const Navigation = React.memo(({ letters }) => {
+  Navigation.displayName = 'Navigation'
+  const [selected, setSelected] = useState(null)
+
+  useEffect(
+    () => {
+      if (letters.length > 0) {
+        const matches = window.location.href.match(ANCHOR_REGEX)
+        const defaultValue =
+          (matches && matches.length === 2 && matches[1]) || null
+
+        if (defaultValue) {
+          window.location.href = `/#${defaultValue}`
+          setSelected(defaultValue)
+        }
+      }
+    },
+    [letters]
+  )
+
+  return (
+    <nav className="navigation">
+      <ol>
+        {letters.map(letter => {
+          return (
+            <ButtonLink
+              key={letter}
+              onClick={() => setSelected(letter)}
+              label={letter}
+              theme={letter === selected ? 'regular' : 'secondary'}
+              href={`#${letter}`}
+              round
+            />
+          )
+        })}
+      </ol>
+    </nav>
+  )
+})
+
+Navigation.propTypes = {
+  letters: PropTypes.arrayOf(PropTypes.string).isRequired
+}
+Navigation.defaultProps = {
+  letters: []
+}
+
+export default Navigation

--- a/src/components/ContactsList/Navigation/Navigation.spec.jsx
+++ b/src/components/ContactsList/Navigation/Navigation.spec.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Navigation from './Navigation'
+import { mount } from 'enzyme'
+import { render } from '@testing-library/react'
+
+describe('Navigation component', () => {
+  it('render correctly navigation component', () => {
+    const NavigationComponent = renderer
+      .create(<Navigation letters={[]} />)
+      .toJSON()
+    expect(NavigationComponent).toMatchSnapshot()
+  })
+
+  it('render navigation correctly with default props for letters', () => {
+    const NavigationComponent = mount(<Navigation />)
+    expect(NavigationComponent.prop('letters')).toEqual([])
+  })
+
+  it('render navigation correctly with letters', () => {
+    const NavigationComponent = mount(<Navigation letters={['A', 'B']} />)
+    expect(NavigationComponent.prop('letters')).toEqual(['A', 'B'])
+  })
+
+  it('Navigation component renders button link A and B', () => {
+    const { getByText } = render(<Navigation letters={['A', 'B']} />)
+    expect(getByText('A'))
+    expect(getByText('B'))
+  })
+
+  it('Navigation component renders one button link with anchor in href', () => {
+    render(<Navigation letters={['A']} />)
+    document.querySelectorAll('a')
+    expect(document.querySelector('a').getAttribute('href')).toBe('#A')
+  })
+})

--- a/src/components/ContactsList/Navigation/__snapshots__/Navigation.spec.jsx.snap
+++ b/src/components/ContactsList/Navigation/__snapshots__/Navigation.spec.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Navigation component render correctly navigation component 1`] = `
+<nav
+  className="navigation"
+>
+  <ol />
+</nav>
+`;

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -1,6 +1,10 @@
 @require 'settings/palette.styl'
 @require 'components/table.styl'
 
+.contacts-wrapper
+    display flex
+    flex-direction row
+
 .list-wrapper
     width 100%
     max-width 80rem

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -5,6 +5,11 @@
 @require './contactGroups.styl'
 @require './contactImportation.styl'
 @require './contactGroupCreation.styl'
+@require './navigation.styl'
+
+// @stylint off
+[role=main]
+    scroll-behavior smooth
 
 [aria-hidden=true]
     display initial

--- a/src/styles/navigation.styl
+++ b/src/styles/navigation.styl
@@ -1,0 +1,26 @@
+.navigation
+    z-index 100
+    position fixed
+    left calc(100% - 3rem)
+
+    height 100%
+    overflow-y auto
+
+    // high resolution
+    @media (min-width: 1300px)
+        left calc(50% + 41rem)
+
+    > ol
+        display flex
+        flex-direction column
+
+        padding 0
+
+        > a
+            border 1px
+            border-color lightgray
+            box-shadow 0 0 3px 0 rgba(0, 0, 0, .25)
+            margin-bottom .5rem
+
+.navigation::-webkit-scrollbar
+    display none


### PR DESCRIPTION
### Ajout de navigation par lettre des contacts

- Lorsque l'on clique sur une lettre on affiche les contacts correspondants à celle sélectionnée. (de façon smooth)

- Le pannel de navigation reste toujours visible à l'écran
- Fonctionne sur mobile et écrans disposants d'une haute définition (responsive)
- Possibilité d'envoyer le lien pour afficher directement les contacts 
**Exemple :** 
Envoi du lien _http://contacts.cozy.tools:8080/#C_  affichera directement les contacts commençant par la lettre C (s'ils existent).
