### PR TITLE
fix: Sort contact after contact edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@testing-library/react": "10.4.9",
     "classnames": "2.2.6",
     "cozy-bar": "7.15.2",
-    "cozy-client": "13.21.0",
+    "cozy-client": "14.6.0",
     "cozy-doctypes": "1.72.2",
     "cozy-flags": "1.10.0",
     "cozy-logger": "1.6.0",

--- a/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
@@ -30,7 +30,7 @@ describe('formValuesToContact', () => {
       fullname: 'John Doe',
       indexes: {
         byFamilyNameGivenNameEmailCozyUrl:
-          'Doejohnjohn.doe@cozycloud.ccjohndoe.mycozy.cloud'
+          'doejohnjohn.doe@cozycloud.ccjohndoe.mycozy.cloud'
       },
       jobTitle: 'Dreamer',
       metadata: { cozy: true, version: 1 },
@@ -90,7 +90,7 @@ describe('formValuesToContact', () => {
       displayName: 'Jane Doe',
       email: [],
       fullname: 'Jane Doe',
-      indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Doejane' },
+      indexes: { byFamilyNameGivenNameEmailCozyUrl: 'doejane' },
       jobTitle: '',
       metadata: { cozy: true, version: 1 },
       name: { familyName: 'Doe', givenName: 'Jane' },

--- a/src/components/ContactCard/ContactForm/index.spec.jsx
+++ b/src/components/ContactCard/ContactForm/index.spec.jsx
@@ -86,7 +86,7 @@ describe('ContactForm', () => {
       fullname: 'Jean-Claude Van Cozy',
       indexes: {
         byFamilyNameGivenNameEmailCozyUrl:
-          'Van cozyjean-claudejcvc@cozy.cloudjcvd.cozy.cloud'
+          'van cozyjean-claudejcvc@cozy.cloudjcvd.cozy.cloud'
       },
       jobTitle: 'Dreamer',
       metadata: { cozy: true, version: 1 },
@@ -168,7 +168,7 @@ describe('ContactForm', () => {
       displayName: '',
       email: [],
       fullname: '',
-      indexes: { byFamilyNameGivenNameEmailCozyUrl: {} },
+      indexes: { byFamilyNameGivenNameEmailCozyUrl: null },
       jobTitle: '',
       metadata: { cozy: true, version: 1 },
       name: { familyName: undefined, givenName: undefined },

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+
 import flag from 'cozy-flags'
 import Button from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
@@ -18,7 +19,7 @@ class ContactsList extends Component {
     if (contacts.length === 0) {
       return <ContactsEmptyList />
     } else {
-      const allContactsSelected = contacts.length === selection.length
+      const isAllContactsSelected = contacts.length === selection.length
       const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
 
       return (
@@ -27,21 +28,21 @@ class ContactsList extends Component {
             <div>
               <Button
                 label={
-                  allContactsSelected ? t('unselect-all') : t('select-all')
+                  isAllContactsSelected ? t('unselect-all') : t('select-all')
                 }
                 theme="secondary"
                 onClick={() =>
-                  allContactsSelected ? clearSelection() : selectAll(contacts)
+                  isAllContactsSelected ? clearSelection() : selectAll(contacts)
                 }
               />
             </div>
           )}
           <ol className="list-contact">
-            {Object.keys(categorizedContacts).map(header => (
+            {Object.entries(categorizedContacts).map(([header, contacts]) => (
               <li key={`cat-${header}`}>
                 <ContactHeaderRow key={header} header={header} />
                 <ol className="sublist-contact">
-                  {categorizedContacts[header].map(contact => (
+                  {contacts.map(contact => (
                     <li key={`contact-${contact._id}`}>
                       <ContactRow
                         id={contact._id}

--- a/src/helpers/contactList.js
+++ b/src/helpers/contactList.js
@@ -10,7 +10,7 @@ import get from 'lodash/get'
 export const categorizeContacts = (contacts, emptyHeader) => {
   return contacts.reduce((acc, contact) => {
     const index = get(contact, 'indexes.byFamilyNameGivenNameEmailCozyUrl', '')
-    const header = index[0] || emptyHeader
+    const header = (index !== null && index[0]) || emptyHeader
     acc[header] = acc[header] || []
     acc[header].push(contact)
     return acc

--- a/src/helpers/contactList.js
+++ b/src/helpers/contactList.js
@@ -1,11 +1,11 @@
-import { get } from 'lodash'
+import get from 'lodash/get'
 
 /**
  * Categorize contacts by first letter of their indexes.byFamilyNameGivenNameEmailCozyUrl
  * Expl.: all contacts with A as first letter will be in A category
- * @param {array} contacts - array of io.cozy.contact documents
- * @param {string} emptyHeader - header for contacts with no indexes.byFamilyNameGivenNameEmailCozyUrl
- * @returns {object} categorized contacts
+ * @param {array} contacts - Array of io.cozy.contact documents
+ * @param {string} emptyHeader - Header for contacts with no indexes.byFamilyNameGivenNameEmailCozyUrl
+ * @returns {object} Categorized contacts
  */
 export const categorizeContacts = (contacts, emptyHeader) => {
   return contacts.reduce((acc, contact) => {

--- a/src/helpers/contactList.spec.js
+++ b/src/helpers/contactList.spec.js
@@ -1,6 +1,6 @@
 import { categorizeContacts } from './contactList'
 
-describe('Categorize contacts', () => {
+describe('categorizeContacts', () => {
   it('should categorize contacts by indexes.byFamilyNameGivenNameEmailCozyUrl', () => {
     const contacts = [
       { name: 'Alex', indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' } },

--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash'
+import sortBy from 'lodash/sortBy'
 import { models } from 'cozy-client'
 const {
   getFullname,
@@ -121,10 +121,10 @@ export const harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl = (
     updateIndexFullNameAndDisplayName(contact)
   )
   const concatedContacts = contactsWithIndexes.concat(updatedContacts)
-  const sortedData = sortBy(concatedContacts, [
+  const sortedContacts = sortBy(concatedContacts, [
     'indexes.byFamilyNameGivenNameEmailCozyUrl'
   ])
-  return sortedData
+  return sortedContacts
 }
 
 /**

--- a/src/helpers/contacts.spec.js
+++ b/src/helpers/contacts.spec.js
@@ -143,7 +143,7 @@ describe('updateIndexFullNameAndDisplayName', () => {
       fullname: 'John Doe',
       indexes: {
         byFamilyNameGivenNameEmailCozyUrl:
-          'Doejohnjohn.doe@cozycloud.ccjohndoe.mycozy.cloud'
+          'doejohnjohn.doe@cozycloud.ccjohndoe.mycozy.cloud'
       }
     }
     expect(updateIndexFullNameAndDisplayName(johnDoeContact)).toEqual(expected)
@@ -159,7 +159,7 @@ describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
           familyName: 'Damon'
         },
         indexes: {
-          byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon'
+          byFamilyNameGivenNameEmailCozyUrl: 'mattdamon'
         }
       },
       {
@@ -168,7 +168,7 @@ describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
           familyName: 'Doe'
         },
         indexes: {
-          byFamilyNameGivenNameEmailCozyUrl: 'Johndoe'
+          byFamilyNameGivenNameEmailCozyUrl: 'johndoe'
         }
       }
     ]
@@ -193,21 +193,21 @@ describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
         displayName: 'Anton Bradbury',
         fullname: 'Anton Bradbury',
         name: { familyName: 'Bradbury', givenName: 'Anton' },
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Bradburyanton' }
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'bradburyanton' }
       },
       {
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Johndoe' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'johndoe' },
         name: { familyName: 'Doe', givenName: 'John' }
       },
       {
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'mattdamon' },
         name: { familyName: 'Damon', givenName: 'Matt' }
       },
       {
         displayName: 'William Wallace',
         fullname: 'William Wallace',
         name: { familyName: 'Wallace', givenName: 'William' },
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Wallacewilliam' }
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'wallacewilliam' }
       }
     ]
 
@@ -230,7 +230,7 @@ describe('reworkContacts', () => {
           familyName: 'Damon'
         },
         indexes: {
-          byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon'
+          byFamilyNameGivenNameEmailCozyUrl: 'mattdamon'
         }
       }
     ]
@@ -248,11 +248,11 @@ describe('reworkContacts', () => {
       {
         displayName: 'Anton Bradbury',
         fullname: 'Anton Bradbury',
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Bradburyanton' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'bradburyanton' },
         name: { familyName: 'Bradbury', givenName: 'Anton' }
       },
       {
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'mattdamon' },
         name: { familyName: 'Damon', givenName: 'Matt' }
       }
     ]
@@ -275,7 +275,7 @@ describe('reworkContacts', () => {
           familyName: 'Damon'
         },
         indexes: {
-          byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon'
+          byFamilyNameGivenNameEmailCozyUrl: 'mattdamon'
         }
       }
     ]
@@ -291,7 +291,7 @@ describe('reworkContacts', () => {
 
     const expected = [
       {
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Mattdamon' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'mattdamon' },
         name: { familyName: 'Damon', givenName: 'Matt' }
       },
       { name: { familyName: 'Bradbury', givenName: 'Anton' } }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,15 +3342,15 @@ cozy-client@13.15.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@13.21.0, cozy-client@^13.13.0:
-  version "13.21.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.21.0.tgz#931e3056c933d0760567c734641e3c830381328d"
-  integrity sha512-Rv0Uv7iJdyRDCjFqOj0O1wUlwtCdrWv4QPHqu9uRlltsGuAIXi/bPaFFT3xB6YucdjnPwcd8hjLgCoAGWWbw+A==
+cozy-client@13.8.3:
+  version "13.8.3"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.8.3.tgz#0bf27284fd2b7708a3ea37fc77e3d58fc923f3db"
+  integrity sha512-SLipjE0rh5YLQBuvOi8yeXTcQeuvdfzJD5B/TTlwgOsWcvJuLh5yazOLtL8A0oRty8SsCWWZe/SbGqVlI7Ue6Q==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^13.20.2"
+    cozy-stack-client "^13.8.3"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -3364,15 +3364,37 @@ cozy-client@13.21.0, cozy-client@^13.13.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@13.8.3:
-  version "13.8.3"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.8.3.tgz#0bf27284fd2b7708a3ea37fc77e3d58fc923f3db"
-  integrity sha512-SLipjE0rh5YLQBuvOi8yeXTcQeuvdfzJD5B/TTlwgOsWcvJuLh5yazOLtL8A0oRty8SsCWWZe/SbGqVlI7Ue6Q==
+cozy-client@14.6.0:
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-14.6.0.tgz#634d6b545a8a7c5e0e07878c50247ec256677e07"
+  integrity sha512-IbaED4CMPpFbiNoceGex+J5LfbnVgiLiYPcyDR/xrwoc4P2gjZ4XFuNfoM7LDe17iSGGetsY+XVaim+UVpzejw==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^13.8.3"
+    cozy-stack-client "^14.1.2"
+    isomorphic-fetch "^2.2.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    minilog "https://github.com/cozy/minilog.git#master"
+    open "^7.0.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "^3.7.2"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
+cozy-client@^13.13.0:
+  version "13.21.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.21.0.tgz#931e3056c933d0760567c734641e3c830381328d"
+  integrity sha512-Rv0Uv7iJdyRDCjFqOj0O1wUlwtCdrWv4QPHqu9uRlltsGuAIXi/bPaFFT3xB6YucdjnPwcd8hjLgCoAGWWbw+A==
+  dependencies:
+    btoa "^1.2.1"
+    cozy-device-helper "^1.7.3"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^13.20.2"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -3561,6 +3583,15 @@ cozy-stack-client@^13.12.1, cozy-stack-client@^13.20.2, cozy-stack-client@^13.8.
   version "13.20.2"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-13.20.2.tgz#2ff55f93dca809b7ec82ec0afc88a3bc041383c1"
   integrity sha512-9j52p+0/kw5CAO42hPCqjV1ESwU/My79bfjF96wZRrGMFAciL+gGQy4wVeTpPlYvWIGIIbchFrUl8rQVkMVWYA==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^14.1.2:
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-14.1.2.tgz#606ce89cabf4def2875cb8749b28b3ee8b96d18f"
+  integrity sha512-0IyYvBQu+vuwN9qe6PHA7khXBQT8TGSjVia7SVTGQ88tEFSLLGXjfZe3pkZQ1ihBdJvmeon12dm0BWeEb+9KZw==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
Due to a change in cozy-client behavior https://github.com/cozy/cozy-client/pull/785, this is a simple consistency update.

- the value of the `Indexes` attribute is now a `null` rather than a `{}` when it should be empty.
- bonus : some cleans up