### PR TITLE
fix: Remove accents in categorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "redux": "4.0.4",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
+    "remove-accents": "0.4.2",
     "yarn-run-all": "3.1.1"
   },
   "resolutions": {

--- a/src/helpers/contactList.js
+++ b/src/helpers/contactList.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import removeAccents from 'remove-accents'
 
 /**
  * Categorize contacts by first letter of their indexes.byFamilyNameGivenNameEmailCozyUrl
@@ -10,7 +11,8 @@ import get from 'lodash/get'
 export const categorizeContacts = (contacts, emptyHeader) => {
   return contacts.reduce((acc, contact) => {
     const index = get(contact, 'indexes.byFamilyNameGivenNameEmailCozyUrl', '')
-    const header = (index !== null && index[0]) || emptyHeader
+    const hasIndex = index !== null && index.length > 0
+    const header = (hasIndex && removeAccents(index[0])) || emptyHeader
     acc[header] = acc[header] || []
     acc[header].push(contact)
     return acc

--- a/src/helpers/contactList.spec.js
+++ b/src/helpers/contactList.spec.js
@@ -10,13 +10,17 @@ describe('categorizeContacts', () => {
       { name: 'Xavier', indexes: { byFamilyNameGivenNameEmailCozyUrl: 'X' } },
       { name: 'Zorro', indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Z' } },
       { name: '', indexes: { byFamilyNameGivenNameEmailCozyUrl: '' } },
-      { name: {}, indexes: { byFamilyNameGivenNameEmailCozyUrl: {} } }
+      { name: {}, indexes: { byFamilyNameGivenNameEmailCozyUrl: {} } },
+      { name: 'John', indexes: { byFamilyNameGivenNameEmailCozyUrl: null } },
+      { name: 'Àlbert', indexes: { byFamilyNameGivenNameEmailCozyUrl: 'À' } },
+      { name: 'Èllen', indexes: { byFamilyNameGivenNameEmailCozyUrl: 'È' } }
     ]
     const categorizedContacts = categorizeContacts(contacts, 'EMPTY')
     expect(categorizedContacts).toEqual({
       A: [
         { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }, name: 'Alex' },
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }, name: 'Alan' }
+        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }, name: 'Alan' },
+        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'À' }, name: 'Àlbert' }
       ],
       B: [
         { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'B' }, name: 'Bernard' }
@@ -24,9 +28,13 @@ describe('categorizeContacts', () => {
       C: [
         { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'C' }, name: 'Cleo' }
       ],
+      E: [
+        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'È' }, name: 'Èllen' }
+      ],
       EMPTY: [
         { indexes: { byFamilyNameGivenNameEmailCozyUrl: '' }, name: '' },
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: {} }, name: {} }
+        { indexes: { byFamilyNameGivenNameEmailCozyUrl: {} }, name: {} },
+        { indexes: { byFamilyNameGivenNameEmailCozyUrl: null }, name: 'John' }
       ],
       X: [
         { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'X' }, name: 'Xavier' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8007,13 +8007,6 @@ minilog@3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   dependencies:
     microee "0.0.6"
 
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
-  dependencies:
-    microee "0.0.6"
-
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -10304,6 +10297,11 @@ remark-parse@^5.0.0:
     unist-util-remove-position "^1.0.0"
     vfile-location "^2.0.0"
     xtend "^4.0.1"
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Accents are removed when creating categories, to regroup contacts for example with "A" and "À" first letter

- Add test for null Indexes

According to https://medium.com/javascript-in-plain-english/not-so-obvious-removal-of-diacritics-in-javascript-explained-and-done-right-52f4aeb3c85 we chose to use `remove-accents`