### PR TITLE
fix: Additional name information and attributes are erased after editing a contact

### DIFF
--- a/src/components/ContactCard/ContactForm/formValuesToContact.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.js
@@ -1,4 +1,4 @@
-import get from 'lodash/get'
+import merge from 'lodash/merge'
 import { updateIndexFullNameAndDisplayName } from '../../../helpers/contacts'
 
 const formValuesToContact = (data, oldContact) => {
@@ -65,13 +65,14 @@ const formValuesToContact = (data, oldContact) => {
       }
     },
     metadata: {
-      ...get(oldContact, 'metadata', {}),
       version: 1,
       cozy: true
     }
   }
 
-  return updateIndexFullNameAndDisplayName(contactWithFormValues)
+  return updateIndexFullNameAndDisplayName(
+    merge({ ...oldContact }, contactWithFormValues)
+  )
 }
 
 export default formValuesToContact

--- a/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
+++ b/src/components/ContactCard/ContactForm/formValuesToContact.spec.js
@@ -133,4 +133,44 @@ describe('formValuesToContact', () => {
     const result = formValuesToContact(johnDoeFormValues, oldContact)
     expect(result.metadata).toEqual(expectedMetadata)
   })
+
+  it('should not erase additional information if it was present in the contact', () => {
+    const oldContact = {
+      name: {
+        additionalName: 'J.',
+        familyName: 'House',
+        givenName: 'Gregory',
+        namePrefix: 'Dr.',
+        nameSuffix: 'III'
+      },
+      me: true
+    }
+    const expected = {
+      name: {
+        additionalName: 'J.',
+        familyName: 'Doe',
+        givenName: 'John',
+        namePrefix: 'Dr.',
+        nameSuffix: 'III'
+      },
+      me: true
+    }
+
+    const result = formValuesToContact(johnDoeFormValues, oldContact)
+    Object.keys(oldContact).map(key =>
+      expect(result[key]).toEqual(expected[key])
+    )
+  })
+
+  it('should not erase attributes not in the doctype if it was present in the contact', () => {
+    const oldContact = {
+      otherInfoNotInDoctype: {
+        information: 'Lorem Ipsum'
+      }
+    }
+    const expected = { information: 'Lorem Ipsum' }
+
+    const result = formValuesToContact(johnDoeFormValues, oldContact)
+    expect(result.otherInfoNotInDoctype).toEqual(expected)
+  })
 })


### PR DESCRIPTION
For imported contacts (vcard, google...), there may be other attributes than those supported by Cozy. When editing a contact, we must therefore keep these attributes instead of deleting them.
- we keep now prefix, suffix etc. of a contact name if present
- we keep now attributes present in the doctype, but not modified by the form
- we keep now other attributes not in the doctype