### PR TITLE
refactor: Use singleDocData in queryContactById definition

### DIFF
--- a/src/components/Modals/ContactCardModal.jsx
+++ b/src/components/Modals/ContactCardModal.jsx
@@ -62,7 +62,7 @@ const ContactCardModal = props => {
       {dataHaveBeenLoaded ? (
         <DumbContactCardModal
           editMode={editMode}
-          contact={resultContactById.data[0]}
+          contact={resultContactById.data}
           allGroups={resultAllGroups.data}
           t={t}
           toggleConfirmDeleteModal={toggleConfirmDeleteModal}

--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -7,7 +7,8 @@ export const buildContactQuery = id => ({
   definition: () => Q(DOCTYPE_CONTACTS).getById(id),
   options: {
     as: `contactById-${id}`,
-    fetchPolicy: olderThan30sec
+    fetchPolicy: olderThan30sec,
+    singleDocData: true
   }
 })
 


### PR DESCRIPTION
Use new singleDocData option in query definition to fetch contact by id