### PR TITLE
feat/scroll to group

### DIFF
--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -15,6 +15,38 @@ import withSelection from '../Selection/selectionContainer'
 const getGroupId = key => `contact-group-${key}`
 
 class ContactsList extends Component {
+  componentDidMount() {
+    document.addEventListener('keyup', this.onKeyUp)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keyup', this.onKeyUp)
+  }
+
+  onKeyUp(event) {
+    const { key } = event
+
+    if (!key.match(/^[a-z]$/i)) {
+      /**
+       * Ignore keyup for non letter keys
+       * the `i` flag is needed when caps lock is activated
+       */
+      return
+    }
+
+    this.scrollToGroup(key)
+  }
+
+  scrollToGroup(id) {
+    const groupElement = document.getElementById(getGroupId(id))
+
+    if (groupElement) {
+      groupElement.scrollIntoView({
+        behavior: 'smooth'
+      })
+    }
+  }
+
   render() {
     const { clearSelection, contacts, selection, selectAll, t } = this.props
 

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -23,7 +23,7 @@ class ContactsList extends Component {
     document.removeEventListener('keyup', this.onKeyUp)
   }
 
-  onKeyUp(event) {
+  onKeyUp = event => {
     const { key } = event
 
     if (!key.match(/^[a-z]$/i)) {

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -12,6 +12,8 @@ import ContactHeaderRow from './ContactHeaderRow'
 
 import withSelection from '../Selection/selectionContainer'
 
+const getGroupId = key => `contact-group-${key}`
+
 class ContactsList extends Component {
   render() {
     const { clearSelection, contacts, selection, selectAll, t } = this.props
@@ -39,7 +41,7 @@ class ContactsList extends Component {
           )}
           <ol className="list-contact">
             {Object.entries(categorizedContacts).map(([header, contacts]) => (
-              <li key={`cat-${header}`}>
+              <li key={`cat-${header}`} id={getGroupId(header)}>
                 <ContactHeaderRow key={header} header={header} />
                 <ol className="sublist-contact">
                   {contacts.map(contact => (

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -13,7 +13,7 @@ import ContactHeaderRow from './ContactHeaderRow'
 import withModal from '../HOCs/withModal'
 import withSelection from '../Selection/selectionContainer'
 
-const getGroupId = key => `contact-group-${key}`
+export const getGroupId = key => `contact-group-${key}`
 
 class ContactsList extends Component {
   componentDidMount() {
@@ -39,8 +39,13 @@ class ContactsList extends Component {
   }
 
   scrollToGroup(id) {
+    // guard needed for testing purposes
+    if (!this.containerRef) return
+
     const { show: isModalShown } = this.props
-    const groupElement = document.getElementById(getGroupId(id))
+    const [groupElement] = this.containerRef.getElementsByClassName(
+      getGroupId(id)
+    )
 
     if (!isModalShown && groupElement) {
       groupElement.scrollIntoView({
@@ -59,7 +64,7 @@ class ContactsList extends Component {
       const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
 
       return (
-        <div className="list-wrapper">
+        <div className="list-wrapper" ref={ref => (this.containerRef = ref)}>
           {flag('select-all-contacts') && (
             <div>
               <Button
@@ -75,7 +80,7 @@ class ContactsList extends Component {
           )}
           <ol className="list-contact">
             {Object.entries(categorizedContacts).map(([header, contacts]) => (
-              <li key={`cat-${header}`} id={getGroupId(header)}>
+              <li key={`cat-${header}`} className={getGroupId(header)}>
                 <ContactHeaderRow key={header} header={header} />
                 <ol className="sublist-contact">
                   {contacts.map(contact => (

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -10,6 +10,7 @@ import ContactsEmptyList from './ContactsEmptyList'
 import ContactRow from './ContactRow'
 import ContactHeaderRow from './ContactHeaderRow'
 
+import withModal from '../HOCs/withModal'
 import withSelection from '../Selection/selectionContainer'
 
 const getGroupId = key => `contact-group-${key}`
@@ -38,9 +39,10 @@ class ContactsList extends Component {
   }
 
   scrollToGroup(id) {
+    const { show: isModalShown } = this.props
     const groupElement = document.getElementById(getGroupId(id))
 
-    if (groupElement) {
+    if (!isModalShown && groupElement) {
       groupElement.scrollIntoView({
         behavior: 'smooth'
       })
@@ -100,4 +102,4 @@ ContactsList.propTypes = {
 }
 ContactsList.defaultProps = {}
 
-export default translate()(withSelection(ContactsList))
+export default translate()(withModal(withSelection(ContactsList)))

--- a/src/components/ContactsList/ContactsList.spec.js
+++ b/src/components/ContactsList/ContactsList.spec.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { mount } from 'enzyme'
+
+import AppLike from '../../tests/Applike'
+import ContactsList from './ContactsList'
+
+import { johnDoeContact } from '../../helpers/testData'
+
+const fakeContactWithIndexes = {
+  ...johnDoeContact,
+  indexes: {
+    byFamilyNameGivenNameEmailCozyUrl: 'john.doe@cozycloud.cc'
+  }
+}
+
+describe('ContactsList', () => {
+  it('should match the snapshot', () => {
+    const tree = renderer
+      .create(
+        <AppLike>
+          <ContactsList contacts={[fakeContactWithIndexes]} />
+        </AppLike>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should renders an empty state', () => {
+    const contactsListInstance = (
+      <AppLike>
+        <ContactsList contacts={[]} />
+      </AppLike>
+    )
+    const contactslist = mount(contactsListInstance)
+    const contactsemptylist = contactslist.find('ContactsEmptyList')
+    expect(contactsemptylist).toBeDefined()
+  })
+})

--- a/src/components/ContactsList/ContactsList.spec.js
+++ b/src/components/ContactsList/ContactsList.spec.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer'
 import { mount } from 'enzyme'
 
 import AppLike from '../../tests/Applike'
-import ContactsList from './ContactsList'
+import ContactsList, { getGroupId } from './ContactsList'
 
 import { johnDoeContact } from '../../helpers/testData'
 
@@ -13,6 +13,24 @@ const fakeContactWithIndexes = {
     byFamilyNameGivenNameEmailCozyUrl: 'john.doe@cozycloud.cc'
   }
 }
+
+const firstContactLetter = fakeContactWithIndexes.fullname[0].toLowerCase()
+
+const fireKeyupEvent = key => {
+  const keyupEvent = new KeyboardEvent('keyup', { key })
+  document.dispatchEvent(keyupEvent)
+}
+
+let scrollIntoViewSpy
+
+beforeAll(() => {
+  scrollIntoViewSpy = jest.fn()
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy
+})
+
+afterAll(() => {
+  scrollIntoViewSpy.mockRestore()
+})
 
 describe('ContactsList', () => {
   it('should match the snapshot', () => {
@@ -36,4 +54,36 @@ describe('ContactsList', () => {
     const contactsemptylist = contactslist.find('ContactsEmptyList')
     expect(contactsemptylist).toBeDefined()
   })
+
+  it('scrolls to the group on keyup', () => {
+    const contactsListInstance = (
+      <AppLike>
+        <ContactsList contacts={[fakeContactWithIndexes]} />
+      </AppLike>
+    )
+    const contactslist = mount(contactsListInstance)
+    const group = contactslist.find(`.${getGroupId(firstContactLetter)}`)
+    const groupInstance = group.instance()
+
+    // renders a group
+    expect(groupInstance).toBeDefined()
+
+    fireKeyupEvent(firstContactLetter)
+
+    // test (smooth) scrolling
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1)
+    expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: 'smooth' })
+  })
+
+  // it('does not scroll when a modal is open', () => {
+  //   const contactsListInstance = (
+  //     <AppLike>
+  //       <ContactsList contacts={[fakeContactWithIndexes]} show />
+  //     </AppLike>
+  //   )
+
+  //   mount(contactsListInstance)
+  //   fireKeyupEvent(firstContactLetter)
+  //   expect(scrollIntoViewSpy).toHaveBeenCalledTimes(0)
+  // })
 })

--- a/src/components/ContactsList/__snapshots__/ContactsList.spec.js.snap
+++ b/src/components/ContactsList/__snapshots__/ContactsList.spec.js.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContactsList should match the snapshot 1`] = `
+<div
+  className="list-wrapper"
+>
+  <ol
+    className="list-contact"
+  >
+    <li
+      id="contact-group-j"
+    >
+      <div
+        className="divider"
+      >
+        j
+      </div>
+      <ol
+        className="sublist-contact"
+      >
+        <li>
+          <div
+            className="contact"
+            onClick={[Function]}
+          >
+            <div
+              className="contact-selection"
+              onClick={[Function]}
+            >
+              <span
+                data-input="checkbox"
+              >
+                <input
+                  checked={false}
+                  readOnly={true}
+                  type="checkbox"
+                />
+                <label />
+              </span>
+            </div>
+            <div
+              className="contact-identity"
+            >
+              <div
+                className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv"
+                style={
+                  Object {
+                    "backgroundColor": "var(--brightSun)",
+                    "color": "white",
+                  }
+                }
+              >
+                
+                <span
+                  className="styles__c-avatar-initials___310qC"
+                >
+                  JD
+                </span>
+              </div>
+              <div
+                className="u-ellipsis u-ml-1"
+              >
+                <span
+                  className=""
+                >
+                  John
+                   
+                </span>
+                <span
+                  className="u-fw-bold"
+                >
+                  Doe
+                   
+                </span>
+              </div>
+            </div>
+            <div
+              className="contact-email u-ellipsis"
+            >
+              john.doe@cozycloud.cc
+            </div>
+            <div
+              className="contact-phone u-ellipsis"
+            >
+              +33 (2)0 90 00 54 04
+            </div>
+            <div
+              className="contact-cozyurl u-ellipsis"
+            >
+              https://johndoe.mycozy.cloud
+            </div>
+          </div>
+        </li>
+      </ol>
+    </li>
+  </ol>
+  <div />
+</div>
+`;

--- a/src/components/ContactsList/__snapshots__/ContactsList.spec.js.snap
+++ b/src/components/ContactsList/__snapshots__/ContactsList.spec.js.snap
@@ -8,7 +8,7 @@ exports[`ContactsList should match the snapshot 1`] = `
     className="list-contact"
   >
     <li
-      id="contact-group-j"
+      className="contact-group-j"
     >
       <div
         className="divider"

--- a/src/components/HOCs/withModal.jsx
+++ b/src/components/HOCs/withModal.jsx
@@ -1,6 +1,10 @@
 import { connect } from 'react-redux'
 import { showModal, hideModal } from '../../helpers/modalManager'
 
+const mapStateToProps = state => ({
+  ...state.appReducers.ui
+})
+
 const mapDispatchToProps = dispatch => ({
   showModal: modal => {
     return dispatch(showModal(modal))
@@ -12,7 +16,7 @@ const mapDispatchToProps = dispatch => ({
 
 const withModalContainer = component =>
   connect(
-    null,
+    mapStateToProps,
     mapDispatchToProps
   )(component)
 


### PR DESCRIPTION
👋 

## What have been done

When pressing a key (`onkeyup`) on the contacts list, the associated group will be scrolled at the top of the page

Nothing will happen if:
- The modal contact is open
- No group is matching the key pressed

NB: I wanted to add a GIF of the behavior, but I can't launch the application anymore, I keep getting the following error even if restarted the whole processes 🙃 
```
ERRO[0027] GET /apps/settings Not Found(404): Application is not installed  domain="cozy.tools:8080" nspace=http
```

## Testing

The tests have been written following patterns applied for other components

- Rendering tests ✅  
- Scrolling to the group on key up ✅ 
- Not scrolling when the modal is open ❌ (not done because the spy was called 3 times instead of 0, not sure why and I ran out of time to fix it)

## Overall notes

I spent ~3h on this project, I had a lot of issues making everything worked (I talked with Quentin about that)
Testing also took more time than I was expected, it's been honestly a long time since I haven't worked with React classes and Enzyme

I also tried to keep a clean commit history so you can have a better understanding of how I build this feature

## Improvements

The feature is pretty simple but if I had more time I'd:
- Display the letter typed at the center of the screen, in overlay
- Support multiple letters (but it might act as a filter)
