### PR TITLE
fix: Emptied fields not erase in contact

### DIFF
--- a/src/components/ContactCard/ContactForm/index.jsx
+++ b/src/components/ContactCard/ContactForm/index.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Form } from 'react-final-form'
 import arrayMutators from 'final-form-arrays'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import FieldsetTitle from '../../Common/FieldsetTitle'
 import ContactFormField from './ContactFormField'
@@ -26,62 +26,66 @@ export function getSubmitContactForm() {
   return _submitContactForm
 }
 
-const ContactForm = ({ contact, onSubmit, t }) => (
-  <Form
-    mutators={{ ...arrayMutators }}
-    onSubmit={data => onSubmit(formValuesToContact(data, contact))}
-    initialValues={contactToFormValues(contact, t)}
-    render={({ handleSubmit }) => {
-      setSubmitContactForm(handleSubmit)
-      return (
-        <div>
-          <form onSubmit={handleSubmit} className="u-flex u-flex-column">
-            <FieldsetTitle title={t('contact_info')} />
-            {fields.map(
-              ({
-                name,
-                icon,
-                type,
-                required,
-                hasLabel,
-                isArray,
-                labelProps,
-                isMultiline
-              }) => (
-                <ContactFormField
-                  key={name}
-                  name={name}
-                  icon={icon}
-                  label={t(`fields.${name}`)}
-                  t={t}
-                  isArray={isArray}
-                  renderInput={(inputName, id) => (
-                    <ContactFieldInput
-                      id={id}
-                      name={inputName}
-                      type={type}
-                      label={t(`fields.${name}`)}
-                      required={required}
-                      withLabel={hasLabel}
-                      labelPlaceholder={t('fields.label')}
-                      labelProps={labelProps}
-                      isMultiline={isMultiline}
-                    />
-                  )}
-                />
-              )
-            )}
-          </form>
-        </div>
-      )
-    }}
-  />
-)
+const ContactForm = ({ contact, onSubmit }) => {
+  const { t } = useI18n()
+  return (
+    <Form
+      mutators={{ ...arrayMutators }}
+      onSubmit={formValues =>
+        onSubmit(formValuesToContact({ formValues, oldContact: contact, t }))
+      }
+      initialValues={contactToFormValues(contact, t)}
+      render={({ handleSubmit }) => {
+        setSubmitContactForm(handleSubmit)
+        return (
+          <div>
+            <form onSubmit={handleSubmit} className="u-flex u-flex-column">
+              <FieldsetTitle title={t('contact_info')} />
+              {fields.map(
+                ({
+                  name,
+                  icon,
+                  type,
+                  required,
+                  hasLabel,
+                  isArray,
+                  labelProps,
+                  isMultiline
+                }) => (
+                  <ContactFormField
+                    key={name}
+                    name={name}
+                    icon={icon}
+                    label={t(`fields.${name}`)}
+                    t={t}
+                    isArray={isArray}
+                    renderInput={(inputName, id) => (
+                      <ContactFieldInput
+                        id={id}
+                        name={inputName}
+                        type={type}
+                        label={t(`fields.${name}`)}
+                        required={required}
+                        withLabel={hasLabel}
+                        labelPlaceholder={t('fields.label')}
+                        labelProps={labelProps}
+                        isMultiline={isMultiline}
+                      />
+                    )}
+                  />
+                )
+              )}
+            </form>
+          </div>
+        )
+      }}
+    />
+  )
+}
 
 ContactForm.propTypes = {
   contact: fullContactPropTypes,
-  onSubmit: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired
+  onSubmit: PropTypes.func.isRequired
 }
 
-export default translate()(ContactForm)
+export default ContactForm

--- a/src/components/ContactCard/ContactForm/index.spec.jsx
+++ b/src/components/ContactCard/ContactForm/index.spec.jsx
@@ -162,7 +162,7 @@ describe('ContactForm', () => {
   it('should submit empty fields', () => {
     const expected = {
       address: [],
-      birthday: undefined,
+      birthday: '',
       company: '',
       cozy: [],
       displayName: '',
@@ -171,7 +171,7 @@ describe('ContactForm', () => {
       indexes: { byFamilyNameGivenNameEmailCozyUrl: null },
       jobTitle: '',
       metadata: { cozy: true, version: 1 },
-      name: { familyName: undefined, givenName: undefined },
+      name: { familyName: '', givenName: '' },
       note: '',
       phone: [],
       relationships: { groups: { data: [] } }

--- a/src/components/ContactCard/__snapshots__/ContactCard.spec.jsx.snap
+++ b/src/components/ContactCard/__snapshots__/ContactCard.spec.jsx.snap
@@ -156,11 +156,11 @@ Array [
             >
               <a
                 className="u-link"
-                href="https://nominatim.openstreetmap.org/search?format=html&q=48%20Fuller%20Road%2006635%20Stafford%20%20Solomon%20Islands"
+                href="https://nominatim.openstreetmap.org/search?format=html&q=48%20Fuller%20Road%2006635%20Stafford%20Solomon%20Islands"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                48 Fuller Road 06635 Stafford  Solomon Islands
+                48 Fuller Road 06635 Stafford Solomon Islands
               </a>
             </div>
           </div>

--- a/src/components/Modals/ContactFormModal.spec.jsx
+++ b/src/components/Modals/ContactFormModal.spec.jsx
@@ -61,7 +61,7 @@ describe('ContactFormModal component', () => {
 
     const expected = {
       address: [],
-      birthday: undefined,
+      birthday: '',
       company: 'Cozy Cloud',
       cozy: [],
       displayName: '',
@@ -70,7 +70,7 @@ describe('ContactFormModal component', () => {
       indexes: { byFamilyNameGivenNameEmailCozyUrl: null },
       jobTitle: '',
       metadata: { cozy: true, version: 1 },
-      name: { familyName: undefined, givenName: undefined },
+      name: { familyName: '', givenName: '' },
       note: '',
       phone: [],
       relationships: { groups: { data: [] } }
@@ -104,7 +104,7 @@ describe('ContactFormModal component', () => {
 
     const expected = {
       address: [],
-      birthday: undefined,
+      birthday: '',
       company: 'Cozy Cloud',
       cozy: [],
       displayName: 'Doe John',

--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -156,19 +156,29 @@ export const reworkContacts = (
  * @returns {string} - The contact's formatted address
  */
 export const getFormattedAddress = (address, t) => {
-  if (address.formattedAddress) {
+  if (address && address.formattedAddress) {
     return address.formattedAddress
-  } else {
-    const emptyAddress = {
-      street: '',
-      pobox: '',
-      city: '',
-      region: '',
-      postcode: '',
-      country: ''
-    }
-    return t('formatted.address', { ...emptyAddress, ...address }).trim()
   }
+
+  const emptyAddress = {
+    pobox: '',
+    street: '',
+    postcode: '',
+    city: '',
+    region: '',
+    country: ''
+  }
+
+  const unformattedAddress = {
+    ...emptyAddress,
+    ...address
+  }
+
+  return t('formatted.address', unformattedAddress)
+    .trim()
+    .split(' ')
+    .filter(val => val.length > 0)
+    .join(' ')
 }
 
 /**


### PR DESCRIPTION
Emptying a field in the contact form now erase the relative contact data

- removing lodash merge that ignore undefined value (that's why it didn't erase the data, the 'undefined' was replaced by the old value.)
- homogenization (to empty string or array) of empty values after saving the form
- remove unformatted address (to formatted address) only if something change in the address
- refactor to use object as param
- add and fix tests