### PR TITLE
Allow users to filter contacts by leading letter

### DIFF
--- a/src/components/ContactsList/ContactsEmptyList.jsx
+++ b/src/components/ContactsList/ContactsEmptyList.jsx
@@ -16,6 +16,7 @@ import StoreButton from '../Common/StoreButton'
 import EmptyIcon from '../../assets/icons/empty-contact-list.svg'
 import SearchContext from '../Contexts/Search'
 import SelectedGroupContext from '../Contexts/SelectedGroup'
+import SelectedFirstLetterContext from '../Contexts/SelectedFirstLetter'
 import { hasSelectedGroup } from '../../helpers/groups'
 
 const style = { pointerEvents: 'all' }
@@ -31,9 +32,12 @@ const ContactsEmptyList = ({ hideModal, showModal }) => {
   const { isDesktop } = useBreakpoints()
   const { searchValue } = useContext(SearchContext)
   const { selectedGroup } = useContext(SelectedGroupContext)
+  const { selectedFirstLetter } = useContext(SelectedFirstLetterContext)
 
   const isContactsFiltered =
-    searchValue.length > 0 || hasSelectedGroup(selectedGroup)
+    searchValue.length > 0 ||
+    hasSelectedGroup(selectedGroup) ||
+    selectedFirstLetter
 
   const emptyTitle = isContactsFiltered
     ? t('empty.title_filtered')

--- a/src/components/ContentResult.jsx
+++ b/src/components/ContentResult.jsx
@@ -19,7 +19,13 @@ import {
   filterContactsByGroup,
   translatedDefaultSelectedGroup
 } from '../helpers/groups'
-import { filterContactsBySearch, delayedSetThreshold } from '../helpers/search'
+import {
+  filterContactsBySearch,
+  filterContactsByFirstLetter,
+  delayedSetThreshold
+} from '../helpers/search'
+import FirstLetterPicker from './FirstLetterPicker/FirstLetterPicker'
+import SelectedFirstLetterContext from './Contexts/SelectedFirstLetter'
 
 const setGroupsSelectCustomStyles = isMobile => ({
   container: base => ({
@@ -50,6 +56,7 @@ export const ContentResult = ({ contacts, allGroups }) => {
   const { searchValue } = useContext(SearchContext)
   const [filteredContacts, setFilteredContacts] = useState(contacts)
   const { isMobile } = useBreakpoints()
+  const { selectedFirstLetter } = useContext(SelectedFirstLetterContext)
 
   const groupsSelectCustomStyles = setGroupsSelectCustomStyles(isMobile)
   const groupsSelectOptions = setGroupsSelectOptions(
@@ -71,8 +78,18 @@ export const ContentResult = ({ contacts, allGroups }) => {
       filteredContactsByGroup,
       searchValue
     )
-    setFilteredContacts(filteredContactsBySearch)
-  }, [contacts, searchValue, selectedGroup, setFilteredContacts])
+    const filteredContactsByFirstLetter = filterContactsByFirstLetter(
+      filteredContactsBySearch,
+      selectedFirstLetter
+    )
+    setFilteredContacts(filteredContactsByFirstLetter)
+  }, [
+    contacts,
+    searchValue,
+    selectedGroup,
+    selectedFirstLetter,
+    setFilteredContacts
+  ])
 
   return (
     <>
@@ -103,6 +120,7 @@ export const ContentResult = ({ contacts, allGroups }) => {
           right={<Toolbar />}
         />
       )}
+      <FirstLetterPicker />
       <Content>
         <ContactsList contacts={filteredContacts} />
       </Content>

--- a/src/components/ContentResult.spec.jsx
+++ b/src/components/ContentResult.spec.jsx
@@ -191,3 +191,25 @@ describe('ContentResult - search', () => {
     expect(queryByText('Jane')).toBeNull()
   })
 })
+
+describe('ContentResult - first letter', () => {
+  it('should show contacts having a last or first name starting with the requested letter', () => {
+    const contacts = [
+      { _id: '01', name: { givenName: 'John', familyName: 'Connor' } },
+      { _id: '02', name: { givenName: 'Matt', familyName: 'Damon' } },
+      { _id: '03', name: { givenName: 'Donald' } }
+    ]
+
+    const { root } = setup({ contacts })
+    const { getByTestId, getAllByTestId } = root
+
+    // click on the D letter
+    fireEvent.click(getByTestId('letter-filter-d'))
+
+    const contactRows = getAllByTestId('contact-row')
+
+    expect(contactRows.length).toBe(2)
+    expect(contactRows[0].textContent).toMatch('Matt')
+    expect(contactRows[1].textContent).toMatch('Donald')
+  })
+})

--- a/src/components/Contexts/SelectedFirstLetter.jsx
+++ b/src/components/Contexts/SelectedFirstLetter.jsx
@@ -1,0 +1,18 @@
+import React, { createContext, useState } from 'react'
+
+const SelectedFirstLetterContext = createContext()
+
+const SelectedFirstLetterProvider = ({ children }) => {
+  const [selectedFirstLetter, setSelectedFirstLetter] = useState(null)
+  const contextValue = { selectedFirstLetter, setSelectedFirstLetter }
+
+  return (
+    <SelectedFirstLetterContext.Provider value={contextValue}>
+      {children}
+    </SelectedFirstLetterContext.Provider>
+  )
+}
+
+export default SelectedFirstLetterContext
+
+export { SelectedFirstLetterProvider }

--- a/src/components/FirstLetterPicker/FirstLetterPicker.jsx
+++ b/src/components/FirstLetterPicker/FirstLetterPicker.jsx
@@ -1,3 +1,5 @@
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
 import React, { useContext } from 'react'
 import SelectedFirstLetterContext from '../Contexts/SelectedFirstLetter'
 import Button from 'cozy-ui/transpiled/react/Button'
@@ -7,6 +9,7 @@ import '../../styles/firstLetterPicker.styl'
 const LETTERS = 'abcdefghijklmnopqrstuvwxyz'.split('')
 
 const FirstLetterPicker = () => {
+  const { t } = useI18n()
   const { selectedFirstLetter, setSelectedFirstLetter } = useContext(
     SelectedFirstLetterContext
   )
@@ -15,7 +18,7 @@ const FirstLetterPicker = () => {
     <nav className="first-letter-picker">
       <Button
         data-testid="letter-filter-none"
-        label={'All'}
+        label={t('all')}
         onClick={() => setSelectedFirstLetter(null)}
         size="large"
         subtle

--- a/src/components/FirstLetterPicker/FirstLetterPicker.jsx
+++ b/src/components/FirstLetterPicker/FirstLetterPicker.jsx
@@ -1,5 +1,8 @@
 import React, { useContext } from 'react'
 import SelectedFirstLetterContext from '../Contexts/SelectedFirstLetter'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+import '../../styles/firstLetterPicker.styl'
 
 const LETTERS = 'abcdefghijklmnopqrstuvwxyz'.split('')
 
@@ -9,23 +12,27 @@ const FirstLetterPicker = () => {
   )
 
   return (
-    <nav>
-      <button
+    <nav className="first-letter-picker">
+      <Button
         data-testid="letter-filter-none"
-        disabled={!selectedFirstLetter}
+        label={'All'}
         onClick={() => setSelectedFirstLetter(null)}
-      >
-        All
-      </button>
+        size="large"
+        subtle
+        style={{ padding: '0 8px' }}
+        theme={selectedFirstLetter ? 'secondary' : null}
+      />
       {LETTERS.map(letter => (
-        <button
+        <Button
           data-testid={`letter-filter-${letter}`}
-          disabled={selectedFirstLetter === letter}
           key={letter}
+          label={letter}
           onClick={() => setSelectedFirstLetter(letter)}
-        >
-          {letter}
-        </button>
+          size="large"
+          subtle
+          style={{ padding: '0 8px' }}
+          theme={selectedFirstLetter === letter ? null : 'secondary'}
+        />
       ))}
     </nav>
   )

--- a/src/components/FirstLetterPicker/FirstLetterPicker.jsx
+++ b/src/components/FirstLetterPicker/FirstLetterPicker.jsx
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react'
+import SelectedFirstLetterContext from '../Contexts/SelectedFirstLetter'
+
+const LETTERS = 'abcdefghijklmnopqrstuvwxyz'.split('')
+
+const FirstLetterPicker = () => {
+  const { selectedFirstLetter, setSelectedFirstLetter } = useContext(
+    SelectedFirstLetterContext
+  )
+
+  return (
+    <nav>
+      <button
+        data-testid="letter-filter-none"
+        disabled={!selectedFirstLetter}
+        onClick={() => setSelectedFirstLetter(null)}
+      >
+        All
+      </button>
+      {LETTERS.map(letter => (
+        <button
+          data-testid={`letter-filter-${letter}`}
+          disabled={selectedFirstLetter === letter}
+          key={letter}
+          onClick={() => setSelectedFirstLetter(letter)}
+        >
+          {letter}
+        </button>
+      ))}
+    </nav>
+  )
+}
+
+export default FirstLetterPicker

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -9,8 +9,6 @@ import ContactFormModal from './Modals/ContactFormModal'
 import ContactCardModal from './Modals/ContactCardModal'
 import ImportDropdown from './Common/ImportDropdown'
 
-const style = { pointerEvents: 'all' }
-
 const Toolbar = ({ showModal, hideModal }) => {
   const { t } = useI18n()
 
@@ -31,12 +29,7 @@ const Toolbar = ({ showModal, hideModal }) => {
 
   return (
     <div className="actions">
-      <Button
-        onClick={showContactFormModal}
-        icon="plus"
-        label={t('create_contact')}
-        style={style}
-      />
+      <Button onClick={showContactFormModal} label={t('create_contact')} />
       <ImportDropdown />
     </div>
   )

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -85,3 +85,17 @@ export const delayedSetThreshold = debounce(
   thresholdValue => setThreshold(thresholdValue),
   375
 )
+
+export const filterContactsByFirstLetter = (contacts, letter) => {
+  if (!letter) return contacts
+
+  return contacts.filter(contact => {
+    if (!contact.name) return false
+
+    const { familyName, givenName } = contact.name
+
+    if (familyName) return familyName[0].toLowerCase() === letter
+    if (givenName) return givenName[0].toLowerCase() === letter
+    return false
+  })
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,5 +136,6 @@
   },
   "loading": {
     "fetching_contacts": "Loading of your contacts, please wait."
-  }
+  },
+  "all": "All"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -136,5 +136,6 @@
   },
   "loading": {
     "fetching_contacts": "Estamos cargando sus contactos, por favor espere."
-  }
+  },
+  "all": "Todos"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -136,5 +136,6 @@
   },
   "loading": {
     "fetching_contacts": "Chargement de la liste de vos contacts en cours."
-  }
+  },
+  "all": "Tous"
 }

--- a/src/styles/firstLetterPicker.styl
+++ b/src/styles/firstLetterPicker.styl
@@ -1,0 +1,2 @@
+.first-letter-picker
+  margin: auto

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -14,6 +14,7 @@ import '../../styles/index.styl'
 import setupApp from './setupApp'
 import { SelectedGroupProvider } from '../../components/Contexts/SelectedGroup'
 import { SearchProvider } from '../../components/Contexts/Search'
+import { SelectedFirstLetterProvider } from '../../components/Contexts/SelectedFirstLetter'
 
 const init = () => {
   const { root, store, client, lang, polyglot } = setupApp()
@@ -26,7 +27,9 @@ const init = () => {
             <BreakpointsProvider>
               <SelectedGroupProvider>
                 <SearchProvider>
-                  <App />
+                  <SelectedFirstLetterProvider>
+                    <App />
+                  </SelectedFirstLetterProvider>
                 </SearchProvider>
               </SelectedGroupProvider>
             </BreakpointsProvider>

--- a/src/tests/Applike.jsx
+++ b/src/tests/Applike.jsx
@@ -10,6 +10,7 @@ import configureStore from '../store/configureStore'
 import getCozyClient from './client'
 import { SelectedGroupProvider } from '../components/Contexts/SelectedGroup'
 import { SearchProvider } from '../components/Contexts/Search'
+import { SelectedFirstLetterProvider } from '../components/Contexts/SelectedFirstLetter'
 
 const store = configureStore(getCozyClient(), null, {})
 
@@ -19,7 +20,9 @@ const AppLike = ({ children, client }) => (
       <CozyProvider client={client || getCozyClient()}>
         <I18n lang={'en'} dictRequire={() => langEn}>
           <SelectedGroupProvider>
-            <SearchProvider>{children}</SearchProvider>
+            <SelectedFirstLetterProvider>
+              <SearchProvider>{children}</SearchProvider>
+            </SelectedFirstLetterProvider>
           </SelectedGroupProvider>
         </I18n>
       </CozyProvider>


### PR DESCRIPTION
This PR adds a way for users to filter contacts whose start with a certain letter.

The filtering is applied to contacts' last name if it exist, and first name if it doesn't. If for some reason no first/last name exist, the contact is ignored and excluded for the result.

An `All` button also exists to cancel the filtering and show all contacts.

This filtering works with the search and group filtering already implemented, meaning that filtering by a certain letter if a group has been selected will only show contacts in this group whose name start with said letter.