### PR TITLE
fix: Safari topbar margin

### DIFF
--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -10,8 +10,9 @@ main > [role=main]
     box-shadow 0 4px 4px 0 silver
 
 .topbar
-    max-width 80rem
     display flex
+    flex 1 0 auto
+    max-width 80rem
     width 100%
     margin 1rem auto
 


### PR DESCRIPTION
Prevent Topbar to be shrinked, specially in Safari