### PR TITLE
fix: Topbar height with just few contacts

### DIFF
--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -11,7 +11,7 @@ main > [role=main]
 
 .topbar
     display flex
-    flex 1 0 auto
+    flex-shrink 0
     max-width 80rem
     width 100%
     margin 1rem auto


### PR DESCRIPTION
Topbar height is too high when only few contacts

will be merged as soon as CI will be green