### PR TITLE
Wip: Feature: Contact List First Letter Category Quick Nav 

### DIFF
--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -9,13 +9,16 @@ import { categorizeContacts } from '../../helpers/contactList'
 
 const CategorizedList = ({ contacts }) => {
   const { t } = useI18n()
-  const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+  const { letters, categorizedContacts } = categorizeContacts(
+    contacts,
+    t('empty-list')
+  )
 
   return (
     <ol className="list-contact">
       {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <li key={`cat-${header}`}>
-          <ContactHeaderRow key={header} header={header} />
+        <li key={`cat-${header}`} id={`CategorizedList-cat-${header}`}>
+          <ContactHeaderRow key={header} header={header} letters={letters} />
           <ContactsSubList contacts={contacts} />
         </li>
       ))}

--- a/src/components/ContactsList/ContactHeaderRow.jsx
+++ b/src/components/ContactsList/ContactHeaderRow.jsx
@@ -1,9 +1,28 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { scrollToElement } from '../../helpers/scrollToElement'
 
-const ContactHeaderRow = props => <div className="divider">{props.header}</div>
+const ContactHeaderRow = props => (
+  <div className="divider">
+    <div className="divider__header">{props.header}</div>
+    <div className="divider__nav">
+      {props.letters.map(letter => (
+        <button
+          key={letter}
+          onClick={() => scrollToElement(`CategorizedList-cat-${letter}`)}
+          className={`divider__nav__item ${
+            props.header === letter ? '-selected' : ''
+          }`}
+        >
+          {letter}
+        </button>
+      ))}
+    </div>
+  </div>
+)
 
 ContactHeaderRow.propTypes = {
-  header: PropTypes.string.isRequired
+  header: PropTypes.string.isRequired,
+  letters: PropTypes.arrayOf(PropTypes.string).isRequired
 }
 export default ContactHeaderRow

--- a/src/components/ContactsList/ContactHeaderRow.spec.jsx
+++ b/src/components/ContactsList/ContactHeaderRow.spec.jsx
@@ -1,0 +1,31 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import ContactHeaderRow from './ContactHeaderRow'
+
+// Mocking scrollToElement
+import { scrollToElement } from '../../helpers/scrollToElement'
+jest.mock('../../helpers/scrollToElement')
+
+describe('ContactHeaderRow', () => {
+  it('should match the ContactHeaderRow snapshot', () => {
+    const tree = renderer
+      .create(<ContactHeaderRow header="A" letters={['A', 'B', 'C']} />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should call scrollToElement on click', () => {
+    const wrapper = mount(
+      <ContactHeaderRow header="A" letters={['A', 'B', 'C']} />
+    )
+    // If we click on B
+    wrapper
+      .find('button')
+      .at(1)
+      .simulate('click')
+    // scrollToElement should be called with DOM id corresponding to B
+    expect(scrollToElement.mock.calls).toEqual([['CategorizedList-cat-B']])
+  })
+})

--- a/src/components/ContactsList/__snapshots__/ContactHeaderRow.spec.jsx.snap
+++ b/src/components/ContactsList/__snapshots__/ContactHeaderRow.spec.jsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContactHeaderRow should match the ContactHeaderRow snapshot 1`] = `
+<div
+  className="divider"
+>
+  <div
+    className="divider__header"
+  >
+    A
+  </div>
+  <div
+    className="divider__nav"
+  >
+    <button
+      className="divider__nav__item -selected"
+      onClick={[Function]}
+    >
+      A
+    </button>
+    <button
+      className="divider__nav__item "
+      onClick={[Function]}
+    >
+      B
+    </button>
+    <button
+      className="divider__nav__item "
+      onClick={[Function]}
+    >
+      C
+    </button>
+  </div>
+</div>
+`;

--- a/src/helpers/contactList.js
+++ b/src/helpers/contactList.js
@@ -3,18 +3,28 @@ import removeAccents from 'remove-accents'
 
 /**
  * Categorize contacts by first letter of their indexes.byFamilyNameGivenNameEmailCozyUrl
+ * Will return 2 objects: an array of first letters (sorted), and a dictionary of contacts.
  * Expl.: all contacts with A as first letter will be in A category
  * @param {array} contacts - Array of io.cozy.contact documents
  * @param {string} emptyHeader - Header for contacts with no indexes.byFamilyNameGivenNameEmailCozyUrl
- * @returns {object} Categorized contacts
+ * @returns {object} { letters: Array of ordered header letters, categorizedContacts: Categorized contacts }
  */
 export const categorizeContacts = (contacts, emptyHeader) => {
-  return contacts.reduce((acc, contact) => {
+  const letters = []
+  const categorizedContacts = contacts.reduce((acc, contact) => {
     const index = get(contact, 'indexes.byFamilyNameGivenNameEmailCozyUrl', '')
     const hasIndex = index !== null && index.length > 0
     const header = (hasIndex && removeAccents(index[0])) || emptyHeader
+    if (!acc[header] && header && header !== 'EMPTY') {
+      letters.push(header)
+    }
     acc[header] = acc[header] || []
     acc[header].push(contact)
     return acc
   }, {})
+
+  return {
+    letters: letters.sort(),
+    categorizedContacts
+  }
 }

--- a/src/helpers/contactList.spec.js
+++ b/src/helpers/contactList.spec.js
@@ -17,31 +17,43 @@ describe('categorizeContacts', () => {
     ]
     const categorizedContacts = categorizeContacts(contacts, 'EMPTY')
     expect(categorizedContacts).toEqual({
-      A: [
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }, name: 'Alex' },
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }, name: 'Alan' },
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'À' }, name: 'Àlbert' }
-      ],
-      B: [
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'B' }, name: 'Bernard' }
-      ],
-      C: [
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'C' }, name: 'Cleo' }
-      ],
-      E: [
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'È' }, name: 'Èllen' }
-      ],
-      EMPTY: [
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: '' }, name: '' },
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: {} }, name: {} },
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: null }, name: 'John' }
-      ],
-      X: [
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'X' }, name: 'Xavier' }
-      ],
-      Z: [
-        { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Z' }, name: 'Zorro' }
-      ]
+      letters: ['A', 'B', 'C', 'E', 'X', 'Z'],
+      categorizedContacts: {
+        A: [
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }, name: 'Alex' },
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }, name: 'Alan' },
+          {
+            indexes: { byFamilyNameGivenNameEmailCozyUrl: 'À' },
+            name: 'Àlbert'
+          }
+        ],
+        B: [
+          {
+            indexes: { byFamilyNameGivenNameEmailCozyUrl: 'B' },
+            name: 'Bernard'
+          }
+        ],
+        C: [
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'C' }, name: 'Cleo' }
+        ],
+        E: [
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'È' }, name: 'Èllen' }
+        ],
+        EMPTY: [
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: '' }, name: '' },
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: {} }, name: {} },
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: null }, name: 'John' }
+        ],
+        X: [
+          {
+            indexes: { byFamilyNameGivenNameEmailCozyUrl: 'X' },
+            name: 'Xavier'
+          }
+        ],
+        Z: [
+          { indexes: { byFamilyNameGivenNameEmailCozyUrl: 'Z' }, name: 'Zorro' }
+        ]
+      }
     })
   })
 })

--- a/src/helpers/scrollToElement.js
+++ b/src/helpers/scrollToElement.js
@@ -1,0 +1,10 @@
+/**
+ * Will scroll smoothly to the given element id.
+ * @param {string} id DOM id of element to which we want to scroll to
+ */
+export const scrollToElement = id => {
+  const element = document.getElementById(id)
+  if (element) {
+    element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+}

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -105,6 +105,25 @@ $reset-list
 .divider
     @extend $table-divider
 
+.divider__header
+    flex: 1
+    margin-right: 1rem
+
+.divider__nav
+    white-space nowrap
+    overflow-x auto
+
+.divider__nav__item
+    border none
+    text-transform uppercase
+    cursor pointer
+    color: inherit
+    text-decoration underline
+
+.divider__nav__item.-selected
+    font-weight bold
+    text-decoration none
+
 // TODO: Find a better way to set the .empty icon size
 .contacts-empty>svg
     height 300px


### PR DESCRIPTION
## First letter category quick nav to category headers

In order for the user to quickly navigate to a contact category, adds a quick nav on top.

- [X] Add quick nav menu to the categories
- [ ] Hide the menu when the category is not sticky ([by using IntersectionObserver](https://ebidel.github.io/demos/sticky-position-event.html))

## Preview

![Capture d’écran de 2020-12-11 12-57-27](https://user-images.githubusercontent.com/1859396/101900893-82392c80-3bb0-11eb-8b7f-41c313f8f819.png)

