### PR TITLE
feat: Add navigation using category letters

### DIFF
--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -17,7 +17,9 @@ const CategorizedList = ({ contacts }) => {
     <Table>
       {Object.entries(categorizedContacts).map(([header, contacts]) => (
         <List key={`cat-${header}`}>
-          <ListSubheader key={header} id={`cat-${header}`}>{header}</ListSubheader>
+          <ListSubheader key={header} id={`cat-${header}`}>
+            {header}
+          </ListSubheader>
           <ContactsSubList contacts={contacts} />
         </List>
       ))}

--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -17,7 +17,7 @@ const CategorizedList = ({ contacts }) => {
     <Table>
       {Object.entries(categorizedContacts).map(([header, contacts]) => (
         <List key={`cat-${header}`}>
-          <ListSubheader key={header}>{header}</ListSubheader>
+          <ListSubheader key={header} id={`cat-${header}`}>{header}</ListSubheader>
           <ContactsSubList contacts={contacts} />
         </List>
       ))}

--- a/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.jsx
+++ b/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.jsx
@@ -8,28 +8,27 @@ import { categorizeContacts } from '../../helpers/contactList'
 
 const ContactsListAlphabeticalShortcuts = ({ contacts }) => {
   const { t } = useI18n()
-  
-  const isCategorisedList = () => {
-    const { searchValue } = useContext(SearchContext)
-    
-    return searchValue.length === 0;
+
+  const { searchValue } = useContext(SearchContext)
+
+  if (searchValue.length > 0) {
+    return null
   }
-  
-  if (!isCategorisedList()) {
-    return (null)
-  }
-    
+
   const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
 
-  const letterShortcuts = Object
-    .keys(categorizedContacts)
+  const letterShortcuts = Object.keys(categorizedContacts)
     .filter(letter => letter !== 'EMPTY')
-    .sort();
+    .sort()
 
   return (
     <div className="contacts-list-alphabetical-shortcuts">
       {letterShortcuts.map(letter => {
-        return <a key={`#cat-${letter}`} href={`#cat-${letter}`}>{letter.toUpperCase()}</a>
+        return (
+          <a key={`#cat-${letter}`} href={`#cat-${letter}`}>
+            {letter.toUpperCase()}
+          </a>
+        )
       })}
     </div>
   )

--- a/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.jsx
+++ b/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.jsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import SearchContext from '../Contexts/Search'
+import { categorizeContacts } from '../../helpers/contactList'
+
+const ContactsListAlphabeticalShortcuts = ({ contacts }) => {
+  const { t } = useI18n()
+  
+  const isCategorisedList = () => {
+    const { searchValue } = useContext(SearchContext)
+    
+    return searchValue.length === 0;
+  }
+  
+  if (!isCategorisedList()) {
+    return (null)
+  }
+    
+  const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+
+  const letterShortcuts = Object
+    .keys(categorizedContacts)
+    .filter(letter => letter !== 'EMPTY')
+    .sort();
+
+  return (
+    <div className="contacts-list-alphabetical-shortcuts">
+      {letterShortcuts.map(letter => {
+        return <a key={`#cat-${letter}`} href={`#cat-${letter}`}>{letter.toUpperCase()}</a>
+      })}
+    </div>
+  )
+}
+
+ContactsListAlphabeticalShortcuts.propTypes = {
+  contacts: PropTypes.array.isRequired
+}
+ContactsListAlphabeticalShortcuts.defaultProps = {}
+
+export default ContactsListAlphabeticalShortcuts

--- a/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.spec.js
+++ b/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.spec.js
@@ -8,13 +8,18 @@ import ContactsListAlphabeticalShortcuts from './ContactsListAlphabeticalShortcu
 describe('ContactsListAlphabeticalShortcuts', () => {
   it('should display alphabetical shortcuts for 1 letter', () => {
     const contacts = [
-        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } }
+      {
+        name: { familyName: 'Doe', givenName: 'John' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'doejohn' }
+      }
     ]
+
     const alphabeticalShortcutsInstance = (
       <AppLike>
         <ContactsListAlphabeticalShortcuts contacts={contacts} />
       </AppLike>
     )
+
     const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
     const shortcutLinks = alphabeticalShortcuts.find('a')
     expect(shortcutLinks).toBeDefined()
@@ -23,14 +28,22 @@ describe('ContactsListAlphabeticalShortcuts', () => {
 
   it('should display alphabetical shortcuts for 2 letters', () => {
     const contacts = [
-        { name: { familyName: 'Backer', givenName: 'Miles' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "backermiles" } },
-        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } },
+      {
+        name: { familyName: 'Backer', givenName: 'Miles' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'backermiles' }
+      },
+      {
+        name: { familyName: 'Doe', givenName: 'John' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'doejohn' }
+      }
     ]
+
     const alphabeticalShortcutsInstance = (
       <AppLike>
         <ContactsListAlphabeticalShortcuts contacts={contacts} />
       </AppLike>
     )
+
     const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
     const shortcutLinks = alphabeticalShortcuts.find('a')
     expect(shortcutLinks).toBeDefined()
@@ -41,14 +54,22 @@ describe('ContactsListAlphabeticalShortcuts', () => {
 
   it('should display alphabetical shortcuts for 2 ordered letters even if contacts list is not ordered', () => {
     const contacts = [
-        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } },
-        { name: { familyName: 'Backer', givenName: 'Miles' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "backermiles" } },
+      {
+        name: { familyName: 'Doe', givenName: 'John' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'doejohn' }
+      },
+      {
+        name: { familyName: 'Backer', givenName: 'Miles' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'backermiles' }
+      }
     ]
+
     const alphabeticalShortcutsInstance = (
       <AppLike>
         <ContactsListAlphabeticalShortcuts contacts={contacts} />
       </AppLike>
     )
+
     const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
     const shortcutLinks = alphabeticalShortcuts.find('a')
     expect(shortcutLinks).toBeDefined()
@@ -59,11 +80,13 @@ describe('ContactsListAlphabeticalShortcuts', () => {
 
   it('should accept empty array', () => {
     const contacts = []
+
     const alphabeticalShortcutsInstance = (
       <AppLike>
         <ContactsListAlphabeticalShortcuts contacts={contacts} />
       </AppLike>
     )
+
     const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
     const shortcutLinks = alphabeticalShortcuts.find('a')
     expect(shortcutLinks).toBeDefined()
@@ -72,9 +95,18 @@ describe('ContactsListAlphabeticalShortcuts', () => {
 
   it('should match the alphabetical shortcuts snapshot', () => {
     const contacts = [
-        { name: { familyName: 'Backer', givenName: 'Miles' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "backermiles" } },
-        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } },
-        { name: { familyName: 'Carroll', givenName: 'Aiden' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "carrollaiden" } },
+      {
+        name: { familyName: 'Backer', givenName: 'Miles' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'backermiles' }
+      },
+      {
+        name: { familyName: 'Doe', givenName: 'John' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'doejohn' }
+      },
+      {
+        name: { familyName: 'Carroll', givenName: 'Aiden' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'carrollaiden' }
+      }
     ]
 
     const tree = renderer
@@ -84,6 +116,7 @@ describe('ContactsListAlphabeticalShortcuts', () => {
         </AppLike>
       )
       .toJSON()
+
     expect(tree).toMatchSnapshot()
   })
 })

--- a/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.spec.js
+++ b/src/components/ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts.spec.js
@@ -1,0 +1,89 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { mount } from 'enzyme'
+
+import AppLike from '../../tests/Applike'
+import ContactsListAlphabeticalShortcuts from './ContactsListAlphabeticalShortcuts'
+
+describe('ContactsListAlphabeticalShortcuts', () => {
+  it('should display alphabetical shortcuts for 1 letter', () => {
+    const contacts = [
+        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } }
+    ]
+    const alphabeticalShortcutsInstance = (
+      <AppLike>
+        <ContactsListAlphabeticalShortcuts contacts={contacts} />
+      </AppLike>
+    )
+    const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
+    const shortcutLinks = alphabeticalShortcuts.find('a')
+    expect(shortcutLinks).toBeDefined()
+    expect(shortcutLinks.text()).toBe('D')
+  })
+
+  it('should display alphabetical shortcuts for 2 letters', () => {
+    const contacts = [
+        { name: { familyName: 'Backer', givenName: 'Miles' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "backermiles" } },
+        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } },
+    ]
+    const alphabeticalShortcutsInstance = (
+      <AppLike>
+        <ContactsListAlphabeticalShortcuts contacts={contacts} />
+      </AppLike>
+    )
+    const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
+    const shortcutLinks = alphabeticalShortcuts.find('a')
+    expect(shortcutLinks).toBeDefined()
+    expect(shortcutLinks.length).toBe(2)
+    expect(shortcutLinks.at(0).text()).toBe('B')
+    expect(shortcutLinks.at(1).text()).toBe('D')
+  })
+
+  it('should display alphabetical shortcuts for 2 ordered letters even if contacts list is not ordered', () => {
+    const contacts = [
+        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } },
+        { name: { familyName: 'Backer', givenName: 'Miles' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "backermiles" } },
+    ]
+    const alphabeticalShortcutsInstance = (
+      <AppLike>
+        <ContactsListAlphabeticalShortcuts contacts={contacts} />
+      </AppLike>
+    )
+    const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
+    const shortcutLinks = alphabeticalShortcuts.find('a')
+    expect(shortcutLinks).toBeDefined()
+    expect(shortcutLinks.length).toBe(2)
+    expect(shortcutLinks.at(0).text()).toBe('B')
+    expect(shortcutLinks.at(1).text()).toBe('D')
+  })
+
+  it('should accept empty array', () => {
+    const contacts = []
+    const alphabeticalShortcutsInstance = (
+      <AppLike>
+        <ContactsListAlphabeticalShortcuts contacts={contacts} />
+      </AppLike>
+    )
+    const alphabeticalShortcuts = mount(alphabeticalShortcutsInstance)
+    const shortcutLinks = alphabeticalShortcuts.find('a')
+    expect(shortcutLinks).toBeDefined()
+    expect(shortcutLinks.length).toBe(0)
+  })
+
+  it('should match the alphabetical shortcuts snapshot', () => {
+    const contacts = [
+        { name: { familyName: 'Backer', givenName: 'Miles' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "backermiles" } },
+        { name: { familyName: 'Doe', givenName: 'John' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "doejohn" } },
+        { name: { familyName: 'Carroll', givenName: 'Aiden' }, indexes: { byFamilyNameGivenNameEmailCozyUrl: "carrollaiden" } },
+    ]
+
+    const tree = renderer
+      .create(
+        <AppLike>
+          <ContactsListAlphabeticalShortcuts contacts={contacts} />
+        </AppLike>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/ContactsListAlphabeticalShortcuts/__snapshots__/ContactsListAlphabeticalShortcuts.spec.js.snap
+++ b/src/components/ContactsListAlphabeticalShortcuts/__snapshots__/ContactsListAlphabeticalShortcuts.spec.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContactListItem should match the alphabetical shortcuts snapshot 1`] = `
+<div
+  className="contacts-list-alphabetical-shortcuts"
+>
+  <a
+    href="#cat-b"
+  >
+    B
+  </a>
+  <a
+    href="#cat-c"
+  >
+    C
+  </a>
+  <a
+    href="#cat-d"
+  >
+    D
+  </a>
+</div>
+`;

--- a/src/components/ContactsListAlphabeticalShortcuts/__snapshots__/ContactsListAlphabeticalShortcuts.spec.js.snap
+++ b/src/components/ContactsListAlphabeticalShortcuts/__snapshots__/ContactsListAlphabeticalShortcuts.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ContactListItem should match the alphabetical shortcuts snapshot 1`] = `
+exports[`ContactsListAlphabeticalShortcuts should match the alphabetical shortcuts snapshot 1`] = `
 <div
   className="contacts-list-alphabetical-shortcuts"
 >

--- a/src/components/ContentResult.jsx
+++ b/src/components/ContentResult.jsx
@@ -20,6 +20,7 @@ import {
   translatedDefaultSelectedGroup
 } from '../helpers/groups'
 import { filterContactsBySearch, delayedSetThreshold } from '../helpers/search'
+import ContactsListAlphabeticalShortcuts from './ContactsListAlphabeticalShortcuts/ContactsListAlphabeticalShortcuts'
 
 const setGroupsSelectCustomStyles = isMobile => ({
   container: base => ({
@@ -102,6 +103,9 @@ export const ContentResult = ({ contacts, allGroups }) => {
           }
           right={<Toolbar />}
         />
+      )}
+      {flag('alphabetical-navigation') && (
+        <ContactsListAlphabeticalShortcuts contacts={filteredContacts} />
       )}
       <Content>
         <ContactsList contacts={filteredContacts} />

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -70,3 +70,17 @@ main > [role=main]
 .contacts-empty>svg
     height 300px
     width 280px
+
+.contacts-list-alphabetical-shortcuts
+    width 100%
+    max-width 80rem
+    margin 0 auto
+
+    a
+        margin 5px
+        text-decoration none
+        color lightgray
+
+        &:hover
+            text-decoration underline
+            color black


### PR DESCRIPTION
Some "letters" shortcuts have been added on top of the contact list so the user can navigate directly to the corresponding contact section.

![image](https://user-images.githubusercontent.com/1884255/107128402-b2a1fc00-68bd-11eb-9d23-4cc38863618e.png)
