### PR TITLE
feat(search): scroll to section

### DIFF
--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext, useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -8,15 +8,26 @@ import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 
 import ContactsSubList from './ContactsSubList'
 import { categorizeContacts } from '../../helpers/contactList'
+import SearchContext from '../Contexts/Search'
+import { applyRefIfCurrentSection, scrollToSection } from '../../helpers/search'
 
 const CategorizedList = ({ contacts }) => {
   const { t } = useI18n()
   const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+  const ref = useRef()
+  const { searchValue } = useContext(SearchContext)
+
+  useEffect(() => {
+    scrollToSection(searchValue, ref)
+  }, [searchValue])
 
   return (
     <Table>
       {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <List key={`cat-${header}`}>
+        <List
+          key={`cat-${header}`}
+          {...applyRefIfCurrentSection(searchValue, header, ref)}
+        >
           <ListSubheader key={header}>{header}</ListSubheader>
           <ContactsSubList contacts={contacts} />
         </List>

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 
+import { config } from '../../constants/search'
+
 import flag from 'cozy-flags'
 import Button from 'cozy-ui/transpiled/react/Button'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -19,7 +21,10 @@ const ContactsList = ({ contacts, clearSelection, selection, selectAll }) => {
     return <ContactsEmptyList />
   }
 
-  const List = searchValue.length > 0 ? UncategorizedList : CategorizedList
+  const List =
+    searchValue.length >= config.MIN_SEARCH_TRESHOLD
+      ? UncategorizedList
+      : CategorizedList
   const isAllContactsSelected = contacts.length === selection.length
 
   const handleAllContactSelection = () => {

--- a/src/constants/search.js
+++ b/src/constants/search.js
@@ -1,0 +1,6 @@
+export const config = {
+  MIN_SECTION_TRESHOLD: 1,
+  MIN_SEARCH_TRESHOLD: 3,
+  SCROLL_BEHAVIOR: 'smooth',
+  SCROLL_ALIGNMENT: 'start'
+}

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -1,6 +1,6 @@
 import debounce from 'lodash/debounce'
 import Fuse from 'fuse.js'
-
+import { config } from '../constants/search'
 import flag from 'cozy-flags'
 
 const fuseOptions = {
@@ -61,7 +61,7 @@ const fuse = new Fuse([], fuseOptions)
  * @returns {array} Array of io.cozy.contact documents
  */
 export const filterContactsBySearch = (contacts, searchValue) => {
-  if (searchValue.length === 0) return contacts
+  if (searchValue.length <= config.MIN_SEARCH_TRESHOLD) return contacts
 
   if (flag('search-threshold')) {
     fuse.options.threshold = flag.store.get('search-threshold')
@@ -85,3 +85,30 @@ export const delayedSetThreshold = debounce(
   thresholdValue => setThreshold(thresholdValue),
   375
 )
+
+/**
+ * Scroll to corresponding section when one letter is entered
+ * @param {string} searchValue - Value of search input
+ * @param {object} ref - React ref object
+ * @returns {void}
+ */
+export const scrollToSection = (searchValue, ref) =>
+  ref &&
+  Array.isArray(searchValue.split()) &&
+  searchValue.length === config.MIN_SECTION_TRESHOLD &&
+  ref.current.scrollIntoView({
+    behavior: config.SCROLL_BEHAVIOR,
+    inline: config.SCROLL_ALIGNMENT
+  })
+
+/**
+ * Check if section corresponds to input first letter and returns ref if so
+ * @param {string} searchValue - Value of search input
+ * @param {object} ref - React ref object
+ * @param {string} header - Section letter
+ * @returns {boolean}
+ */
+export const applyRefIfCurrentSection = (searchValue, header, ref) =>
+  searchValue && header && searchValue[0].toLowerCase() === header.toLowerCase()
+    ? { ref }
+    : {}

--- a/src/helpers/search.spec.js
+++ b/src/helpers/search.spec.js
@@ -1,0 +1,31 @@
+import { scrollToSection, applyRefIfCurrentSection } from './search'
+
+describe('scrollToCurrentSection', () => {
+  it('should not throw given incorrect params', () => {
+    expect(scrollToSection(undefined, undefined)).toEqual(undefined)
+  })
+})
+
+describe('applyRefIfCurrentSection', () => {
+  const ref = 'ref'
+
+  it('should return ref given different casing', () => {
+    expect(applyRefIfCurrentSection('A', 'a', ref)).toEqual({ ref })
+  })
+
+  it('should return an empty object given different letters', () => {
+    expect(applyRefIfCurrentSection('A', 'b', ref)).toEqual({})
+  })
+
+  it('should return an empty object missing param 1', () => {
+    expect(applyRefIfCurrentSection(undefined, 'b', ref)).toEqual({})
+  })
+
+  it('should return an empty object missing param 2', () => {
+    expect(applyRefIfCurrentSection('A', undefined, ref)).toEqual({})
+  })
+
+  it('should return an empty object missing param 3', () => {
+    expect(applyRefIfCurrentSection('A', 'b', undefined)).toEqual({})
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,7 +5710,7 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global@^4.3.0:
+global@^4.3.0, global@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==


### PR DESCRIPTION
When an user inputs one or two letters, scroll to first letter section without triggering search algo (UX improvement).
Could be interesting to also filter out contacts that do not begin with the first letter (faster search Fuse afterwards). What do you think about that?