### PR TITLE
add alphabetical navigation (letters shortcuts) in categorized list

### DIFF
--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -5,23 +5,69 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Table } from 'cozy-ui/transpiled/react/Table'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import { makeStyles } from '@material-ui/styles'
 
 import ContactsSubList from './ContactsSubList'
+import VerticalLettersChip from './VerticalLettersChip'
 import { categorizeContacts } from '../../helpers/contactList'
+
+const useStyles = makeStyles(() => ({
+  charsChipWrapper: {
+    position: 'absolute',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    width: '100%',
+    height: '100%'
+  }
+}))
+
+const getAlphabetLetters = () => {
+  const alphabet = [],
+    charZCode = 'z'.charCodeAt(0)
+  let i = 'a'.charCodeAt(0)
+  while (i <= charZCode) {
+    alphabet.push(String.fromCharCode(i++))
+  }
+  return alphabet
+}
 
 const CategorizedList = ({ contacts }) => {
   const { t } = useI18n()
-  const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+  const classes = useStyles()
+  const alphabetLetters = React.useMemo(getAlphabetLetters, [])
+  const categorizedContacts = React.useMemo(
+    () => categorizeContacts(contacts, t('empty-list')),
+    [contacts, t]
+  )
+  const categoriesRefs = React.useMemo(
+    () =>
+      Object.keys(categorizedContacts).reduce((refs, cat) => {
+        refs[cat] = React.createRef()
+        return refs
+      }, {}),
+    [categorizedContacts]
+  )
 
   return (
-    <Table>
-      {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <List key={`cat-${header}`}>
-          <ListSubheader key={header}>{header}</ListSubheader>
-          <ContactsSubList contacts={contacts} />
-        </List>
-      ))}
-    </Table>
+    <div>
+      <Table>
+        <div className={classes.charsChipWrapper}>
+          <VerticalLettersChip
+            letters={alphabetLetters.map(letter => ({
+              name: letter,
+              ref: categoriesRefs[letter]
+            }))}
+          />
+        </div>
+
+        {Object.entries(categorizedContacts).map(([header, contacts]) => (
+          <List key={`cat-${header}`} ref={categoriesRefs[header]}>
+            <ListSubheader key={header}>{header}</ListSubheader>
+            <ContactsSubList contacts={contacts} />
+          </List>
+        ))}
+      </Table>
+    </div>
   )
 }
 

--- a/src/components/ContactsList/VerticalLettersChip.jsx
+++ b/src/components/ContactsList/VerticalLettersChip.jsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { makeStyles } from '@material-ui/styles'
+import palette from 'cozy-ui/transpiled/react/palette'
+import Chip from 'cozy-ui/transpiled/react/Chip'
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: 'none',
+    '@supports (position: sticky)': {
+      position: 'sticky',
+      display: 'flex',
+      flexDirection: 'column',
+      width: '1.5rem',
+      height: 'fit-content',
+      top: '3rem',
+      right: '.5rem',
+      margin: 0,
+      padding: '.5rem',
+      zIndex: 2,
+      textTransform: 'uppercase',
+      backgroundColor: 'transparent'
+    }
+  },
+  letter: {
+    cursor: 'pointer'
+  },
+  disabledLetter: {
+    color: palette['coolGrey']
+  }
+}))
+
+const VerticalLettersChip = ({ letters }) => {
+  const classes = useStyles()
+
+  return (
+    <Chip
+      className={classes.root}
+      variant="default"
+      data-testid="vertical-letters-chip"
+    >
+      {letters.map(letter => (
+        <div key={`letter-${letter.name}`} className="u-mb-half u-fz-tiny">
+          {letter.ref ? (
+            <a
+              onClick={() =>
+                letter.ref.current.scrollIntoView({ behavior: 'smooth' })
+              }
+              className={`u-link ${classes.letter}`}
+            >
+              {letter.name}
+            </a>
+          ) : (
+            <span className={classes.disabledLetter}>{letter.name}</span>
+          )}
+        </div>
+      ))}
+    </Chip>
+  )
+}
+
+VerticalLettersChip.propTypes = {
+  letters: PropTypes.array.isRequired
+}
+
+export default VerticalLettersChip

--- a/src/components/ContentResult.spec.jsx
+++ b/src/components/ContentResult.spec.jsx
@@ -106,6 +106,14 @@ describe('ContentResult - groups', () => {
       enLocale.filter['all-groups']
     )
   })
+
+  it('should display the vertical chars chip', () => {
+    const { root } = setup()
+
+    const { queryByTestId } = root
+
+    expect(queryByTestId('vertical-letters-chip')).not.toBeNull()
+  })
 })
 
 describe('ContentResult - search', () => {
@@ -189,5 +197,16 @@ describe('ContentResult - search', () => {
     expect(getByText('John')).toBeTruthy()
     expect(queryByText('Matt')).toBeNull()
     expect(queryByText('Jane')).toBeNull()
+  })
+
+  it('should not display the vertical chars chip', async () => {
+    const { root } = setup()
+    const searchValue = 'John'
+
+    const { queryByTestId, getByPlaceholderText } = root
+
+    await search(searchValue, getByPlaceholderText)
+
+    expect(queryByTestId('vertical-letters-chip')).toBeNull()
   })
 })


### PR DESCRIPTION
A vertical chip has been added on the right of the categorized contact list containing alphabet letters, each letter is a shortcut to a category, so the user can navigate directly to the desired category (names starting by the letter).
_See the screenshots for the result_

![image](https://user-images.githubusercontent.com/10755410/114315377-05d33d80-9aff-11eb-9121-cc049193381b.png)
![image](https://user-images.githubusercontent.com/10755410/114315388-14b9f000-9aff-11eb-83a5-0637b4381012.png)
