### PR TITLE
Feat: add user navigation buttons using first character

### DIFF
--- a/src/components/CategorizedListNavigation/CategorizedListNavigation.jsx
+++ b/src/components/CategorizedListNavigation/CategorizedListNavigation.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
+import { Box } from '@material-ui/core'
+import { categorizeContacts } from '../../helpers/contactList'
+
+const CategorizedListNavigation = ({ contacts }) => {
+  const { t } = useI18n()
+  const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+
+  const characterButtonHandler = character => {
+    const targetElement = document.getElementById(`list_${character}`)
+    if (targetElement) {
+      targetElement.scrollIntoView({
+        block: 'start',
+        behavior: 'smooth'
+      })
+    }
+  }
+
+  return (
+    <Box
+      className="topbar"
+      display="flex"
+      flexWrap="wrap"
+      justifyContent="center"
+    >
+      {Object.entries(categorizedContacts).map(([header]) => (
+        <Button
+          key={header}
+          style={{ width: '15px', display: 'inline-block' }}
+          variant="outlined"
+          color="primary"
+          onClick={() => characterButtonHandler(header)}
+        >
+          {header}
+        </Button>
+      ))}
+    </Box>
+  )
+}
+
+export default CategorizedListNavigation

--- a/src/components/CategorizedListNavigation/CategorizedListNavigation.spec.jsx
+++ b/src/components/CategorizedListNavigation/CategorizedListNavigation.spec.jsx
@@ -1,0 +1,56 @@
+import AppLike from '../../tests/Applike'
+import { mount } from 'enzyme'
+import React from 'react'
+import CategorizedListNavigation from './CategorizedListNavigation'
+
+describe('CategorizedListNavigation', () => {
+  it("should render a navigation button 'empty', corresponding to given contact without index", () => {
+    expect.assertions(2)
+
+    const givenContacts = [
+      { _id: '012', name: { familyName: 'Doe', givenName: 'John' } }
+    ]
+    const CategorizedListNavigationInstance = (
+      <AppLike>
+        <CategorizedListNavigation contacts={givenContacts} />
+      </AppLike>
+    )
+    const wrapper = mount(CategorizedListNavigationInstance)
+
+    const navigationButtons = wrapper.find('ForwardRef(Button)')
+    expect(navigationButtons.getElements().length).toEqual(1)
+    expect(navigationButtons.text()).toBe('EMPTY')
+  })
+
+  it('should render navigation buttons corresponding to given contacts with index', () => {
+    const givenContacts = [
+      {
+        _id: '012',
+        name: { familyName: 'Doe', givenName: 'John' },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'D'
+        }
+      },
+      {
+        _id: '013',
+        name: { familyName: 'Snow', givenName: 'John' },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'S'
+        }
+      }
+    ]
+
+    const CategorizedListNavigationInstance = (
+      <AppLike>
+        <CategorizedListNavigation contacts={givenContacts} />
+      </AppLike>
+    )
+    const wrapper = mount(CategorizedListNavigationInstance)
+
+    const navigationButtons = wrapper.find('ForwardRef(Button)')
+    const elements = navigationButtons.getElements()
+    expect(elements.length).toEqual(2)
+    expect(elements[0].props.children).toBe('D')
+    expect(elements[1].props.children).toBe('S')
+  })
+})

--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -16,7 +16,11 @@ const CategorizedList = ({ contacts }) => {
   return (
     <Table>
       {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <List key={`cat-${header}`}>
+        <List
+          key={`cat-${header}`}
+          id={`list_${header}`}
+          data-testid={`list_${header}`}
+        >
           <ListSubheader key={header}>{header}</ListSubheader>
           <ContactsSubList contacts={contacts} />
         </List>

--- a/src/components/ContactsList/CategorizedList.spec.jsx
+++ b/src/components/ContactsList/CategorizedList.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+// import renderer from 'react-test-renderer'
+import { mount } from 'enzyme'
+
+import AppLike from '../../tests/Applike'
+import CategorizedList from './CategorizedList'
+
+describe('CategorizedList', () => {
+  it('should render a categoryzed list with sub header matching given contacts', () => {
+    expect.assertions(2)
+
+    const givenContacts = [
+      {
+        _id: '012',
+        name: { familyName: 'Doe', givenName: 'John' }
+      },
+      {
+        _id: '013',
+        name: { familyName: 'Snow', givenName: 'John' },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'S'
+        }
+      }
+    ]
+    const CategorizedListInstance = (
+      <AppLike>
+        <CategorizedList contacts={givenContacts} />
+      </AppLike>
+    )
+    const wrapper = mount(CategorizedListInstance)
+    const listSubheader = wrapper.find('ForwardRef(ListSubheader)')
+    const contactsSubList = wrapper.find('ContactsSubList')
+
+    expect(listSubheader.getElements().length).toEqual(2)
+    expect(contactsSubList.getElements().length).toEqual(2)
+  })
+})

--- a/src/components/ContactsList/ContactsList.spec.jsx
+++ b/src/components/ContactsList/ContactsList.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import AppLike from '../../tests/Applike'
+import ContactsList from './ContactsList'
+
+describe('ContactsList', () => {
+  it('should render an empty list when given contacts is empty', () => {
+    expect.assertions(1)
+
+    const givenContacts = []
+    const ContactsListInstance = (
+      <AppLike>
+        <ContactsList contacts={givenContacts} />
+      </AppLike>
+    )
+    const wrapper = mount(ContactsListInstance)
+    const contactsEmptyList = wrapper.find('ContactsEmptyList')
+
+    expect(contactsEmptyList.getElements().length).toEqual(1)
+  })
+
+  it('should not render an empty list when given contacts is not empty', () => {
+    expect.assertions(1)
+
+    const givenContacts = [
+      { _id: '012', name: { familyName: 'Doe', givenName: 'John' } }
+    ]
+    const ContactsListInstance = (
+      <AppLike>
+        <ContactsList contacts={givenContacts} />
+      </AppLike>
+    )
+
+    const wrapper = mount(ContactsListInstance)
+    const contactsEmptyList = wrapper.find('ContactsEmptyList')
+
+    expect(contactsEmptyList.getElements().length).toEqual(0)
+  })
+
+  it('should render a categorized list containing given contacts', () => {
+    const givenContacts = [
+      { _id: '012', name: { familyName: 'Doe', givenName: 'John' } },
+      { _id: '123', name: { familyName: 'Snow', givenName: 'John' } }
+    ]
+    const ContactsListInstance = (
+      <AppLike>
+        <ContactsList contacts={givenContacts} />
+      </AppLike>
+    )
+
+    const wrapper = mount(ContactsListInstance)
+
+    const categorizedList = wrapper.find('CategorizedList')
+    const contactListItems = categorizedList.find('ContactListItem')
+
+    expect(categorizedList.getElements().length).toEqual(1)
+    expect(contactListItems.getElements().length).toEqual(2)
+  })
+})

--- a/src/components/ContentResult.jsx
+++ b/src/components/ContentResult.jsx
@@ -20,6 +20,7 @@ import {
   translatedDefaultSelectedGroup
 } from '../helpers/groups'
 import { filterContactsBySearch, delayedSetThreshold } from '../helpers/search'
+import CategorizedListNavigation from './CategorizedListNavigation/CategorizedListNavigation'
 
 const setGroupsSelectCustomStyles = isMobile => ({
   container: base => ({
@@ -76,33 +77,41 @@ export const ContentResult = ({ contacts, allGroups }) => {
 
   return (
     <>
-      {contacts.length >= 1 && (
-        <Header
-          left={
-            <>
-              {flag('search-threshold') && (
-                <div>
-                  <Input onChange={handleSearchThreshold} defaultValue="0.3" />
-                </div>
-              )}
-              <SearchInput />
-              <GroupsSelect
-                className="u-w-100 u-maw-6"
-                allGroups={groupsSelectOptions}
-                value={selectedGroup}
-                onChange={setSelectedGroup}
-                noOptionsMessage={() => t('filter.no-group')}
-                styles={groupsSelectCustomStyles}
-                closeMenuOnSelect={true}
-                components={{
-                  Control: ControlDefaultWithTestId
-                }}
-              />
-            </>
-          }
-          right={<Toolbar />}
-        />
-      )}
+      <>
+        {contacts.length >= 1 && (
+          <Header
+            left={
+              <>
+                {flag('search-threshold') && (
+                  <div>
+                    <Input
+                      onChange={handleSearchThreshold}
+                      defaultValue="0.3"
+                    />
+                  </div>
+                )}
+                <SearchInput />
+                <GroupsSelect
+                  className="u-w-100 u-maw-6"
+                  allGroups={groupsSelectOptions}
+                  value={selectedGroup}
+                  onChange={setSelectedGroup}
+                  noOptionsMessage={() => t('filter.no-group')}
+                  styles={groupsSelectCustomStyles}
+                  closeMenuOnSelect={true}
+                  components={{
+                    Control: ControlDefaultWithTestId
+                  }}
+                />
+              </>
+            }
+            right={<Toolbar />}
+          />
+        )}
+        {contacts.length >= 1 && !searchValue && (
+          <CategorizedListNavigation contacts={filteredContacts} />
+        )}
+      </>
       <Content>
         <ContactsList contacts={filteredContacts} />
       </Content>

--- a/src/components/ContentResult.spec.jsx
+++ b/src/components/ContentResult.spec.jsx
@@ -122,10 +122,10 @@ describe('ContentResult - search', () => {
     const { root } = setup()
     const searchValue = 'John'
 
-    const { queryByText, getByText, getByPlaceholderText } = root
+    const { queryByText, getAllByText, getByPlaceholderText } = root
 
-    // category of the contact
-    expect(getByText('EMPTY')).toBeTruthy()
+    // category of the contact and navigation button
+    expect(getAllByText('EMPTY').length).toBe(2)
 
     await search(searchValue, getByPlaceholderText)
 

--- a/src/components/ContentRework.spec.jsx
+++ b/src/components/ContentRework.spec.jsx
@@ -116,8 +116,8 @@ describe('ContentRework', () => {
 
   it('should have empty section (for contacts without indexes) if service has been launched', () => {
     const { root } = setup()
-    const { getByText } = root
-    expect(getByText('EMPTY'))
+    const { getAllByText } = root
+    expect(getAllByText('EMPTY').length).toEqual(2)
   })
 
   it('should not have empty section (for contacts without indexes) if service has not been launched', () => {


### PR DESCRIPTION
# Feature : navigate in contact list using first character

## What I wanted to do before adding new features

* Node 10 isn't active nor maintained since 30 Apr 2021
** Migrate to the latest https://nodejs.org/en/about/releases/[Node LTS version]

- `npm t` 
    - Fix errors / warnings
    - Add more unit | component tests

- `npm outdated`
    - 27 packages are outdated

- `npm run lint`
    - 6 Warnings due to `!important` => fix it or disable eslint for these erros


## About the new feature

### 1st step - This PR

- Define a list of characters base on contact list headers :
    - Add a new button for each character

### 2nd step

- Refactor previous behavior : 
  - Add a button for each character from alphabet
  - Using existing contacts (or disable a button if no contact matches with it) disable each button without matching header
- Refactor code :
  - Extract headers from contact list

### Nice to have

- Navigate using keyboard : 
    - key A go to 'A'
    - key ➡ or ⬇ go to next character
    - key ⬅ or ⬆ go to previous character

## What I wish to do - later

- Fix z-index of displayed errors when creating a new contact : 
    - Errors are displayed behind the "Create a contact" modal.

## Questions 

- What is 'Transifex' and why do you use it for ?

- I want to know more about `Renovate`, what do you think about it ? + 
I'm currently using `ncu` ...

- Ideas :
    - Do you know link:https://www.testing-library.com/react[@testing-library/react] ?
    => **Yes** but it's declared as dependency, this lib should be a dev-dependency.
    - What about typescript ?
