### PR TITLE
fix: Add realtime to contacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "cozy-doctypes": "1.75.1",
     "cozy-flags": "1.10.0",
     "cozy-logger": "1.6.0",
+    "cozy-realtime": "3.13.0",
     "cozy-ui": "45.0.0-beta.4",
     "cozy-vcard": "0.2.18",
     "final-form": "4.10.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,6 +3,8 @@ import React, { useEffect } from 'react'
 import flow from 'lodash/flow'
 
 import { useClient } from 'cozy-client'
+import { RealTimeQueries } from 'cozy-client'
+
 import flag, { FlagSwitcher } from 'cozy-flags'
 import { Main, Layout } from 'cozy-ui/transpiled/react/Layout'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -42,6 +44,7 @@ const ContactsApp = ({ cleanTrashedGroups }) => {
         <Main>
           {flag('switcher') && <FlagSwitcher />}
           <ContactsSelectionBar />
+          <RealTimeQueries doctype="io.cozy.contacts" />
           <ContentWrapper />
           <Alerter t={t} />
           <ModalManager />

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -1,4 +1,5 @@
 import memoize from 'lodash/memoize'
+import { RealtimePlugin } from 'cozy-realtime'
 
 import configureStore from 'store/configureStore'
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
@@ -14,6 +15,8 @@ const setupApp = memoize(() => {
   const { lang, appName } = getValues(JSON.parse(root.dataset.cozy))
   const polyglot = initTranslation(lang, lang => require(`locales/${lang}`))
   const client = getClient()
+  client.registerPlugin(RealtimePlugin)
+
   const persistedState = {}
 
   const store = configureStore(

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -9,6 +9,7 @@ import { render } from 'react-dom'
 import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import cozyClient, { CozyProvider } from 'cozy-client'
 import { Intents } from 'cozy-interapp'
+import { RealtimePlugin } from 'cozy-realtime'
 
 const renderApp = function(client, appLocale, appData) {
   const IntentHandler = require('components/Intents/IntentHandler').default
@@ -56,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
     token: data.token,
     store: false
   })
+  client.registerPlugin(RealtimePlugin)
 
   renderApp(client, appLocale, data)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,7 +823,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cozy/minilog@1.0.0":
+"@cozy/minilog@1.0.0", "@cozy/minilog@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@cozy/minilog/-/minilog-1.0.0.tgz#1acc1aad849261e931e255a5f181b638315f7b84"
   integrity sha512-IkDHF9CLh0kQeSEVsou59ar/VehvenpbEUjLfwhckJyOUqZnKAWmXy8qrBgMT5Loxr8Xjs2wmMnj0D67wP00eQ==
@@ -3546,6 +3546,14 @@ cozy-logger@1.6.0, cozy-logger@^1.6.0:
   dependencies:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
+
+cozy-realtime@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.13.0.tgz#aea05fbae2b941005f33b298bbe3fb3943d8faba"
+  integrity sha512-DxG/rV1Kw7FO5bYbBLBxQkEJIDBVhqs/xHRGSqYu4ShkQGR+FCrNB9hWSK3b8nGCS/xcskTZvvS+n765QW/MIg==
+  dependencies:
+    "@cozy/minilog" "^1.0.0"
+    cozy-device-helper "^1.12.0"
 
 cozy-realtime@3.2.1:
   version "3.2.1"


### PR DESCRIPTION
When we arrive on the app, we can launch
the service to keep the index up to date.
By doing so, the service can upgrate the
contact's documents.

In that case, if we try to edit / delete a contact
that have been edited by the service, we will get
a 409 error since the app doesn't have the right
version of the document.

To fix this issue, let's connect to the realtime
to get the latest revision if a document is changed
by something.


