### PR TITLE
feat: add a right bar to navigate through contacts by letter

### DIFF
--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -8,20 +8,45 @@ import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 
 import ContactsSubList from './ContactsSubList'
 import { categorizeContacts } from '../../helpers/contactList'
+import HeaderNavigator from './HeaderNavigator'
+
+/**
+ *
+ * @param header: the string containing the header to display
+ * @param contacts: an array containing the contacts to display
+ * @returns A pair of [header, ref, element] where
+ * header is the string containing the header to display,
+ * ref is a reference to the element,
+ * element is the {JSX.Element} containing the contact sublist
+ */
+function getContactSubListWithHeadersAndRef(header, contacts) {
+  const ref = React.createRef()
+  return [
+    header,
+    ref,
+    <List key={`cat-${header}`} ref={ref}>
+      <ListSubheader key={header}>{header}</ListSubheader>
+      <ContactsSubList contacts={contacts} />
+    </List>
+  ]
+}
 
 const CategorizedList = ({ contacts }) => {
   const { t } = useI18n()
   const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
-
+  const sublistsWithHeadersAndRef = Object.entries(categorizedContacts).map(
+    ([header, contacts]) => getContactSubListWithHeadersAndRef(header, contacts)
+  )
+  const headersWithRef = sublistsWithHeadersAndRef.map(([header, ref]) => [
+    header,
+    ref
+  ])
+  const sublists = sublistsWithHeadersAndRef.map(([, , sublist]) => sublist)
   return (
-    <Table>
-      {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <List key={`cat-${header}`}>
-          <ListSubheader key={header}>{header}</ListSubheader>
-          <ContactsSubList contacts={contacts} />
-        </List>
-      ))}
-    </Table>
+    <div className="categorized-list-wrapper">
+      <Table className="table-wrapper">{sublists}</Table>
+      <HeaderNavigator headersWithRef={headersWithRef} />
+    </div>
   )
 }
 

--- a/src/components/ContactsList/HeaderNavigator.jsx
+++ b/src/components/ContactsList/HeaderNavigator.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const getScrollToLink = (label, ref) => {
+  const scrollTo = () => {
+    ref.current.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+  return (
+    <li key={`header-nav-${label}`}>
+      <a onClick={scrollTo}>{label.toUpperCase()}</a>
+    </li>
+  )
+}
+
+/**
+ * A component displaying a list of links. When a link is clicked, the browser scrolls to the appropriate referenced content
+ * @param headersWithRef: an array containing pairs of [header, ref]
+ * where header is the label displayed for the link and ref is a React reference to scroll to.
+ * All the labels are capitalized
+ */
+const HeaderNavigator = ({ headersWithRef }) => {
+  return (
+    <ol className="header-navigator">
+      {headersWithRef.map(([header, ref]) => getScrollToLink(header, ref))}
+    </ol>
+  )
+}
+
+HeaderNavigator.propTypes = {
+  headersWithRef: PropTypes.array.isRequired
+}
+
+export default HeaderNavigator

--- a/src/components/ContactsList/HeaderNavigator.spec.jsx
+++ b/src/components/ContactsList/HeaderNavigator.spec.jsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react'
+import AppLike from '../../tests/Applike'
+import React from 'react'
+import HeaderNavigator from './HeaderNavigator'
+
+const setup = ({ headersWithRef } = {}) => {
+  const root = render(
+    <AppLike>
+      <HeaderNavigator headersWithRef={headersWithRef} />
+    </AppLike>
+  )
+  return { root }
+}
+
+describe('HeaderNavigator', () => {
+  it('should show a capitalized item per header', () => {
+    const { root } = setup({
+      headersWithRef: [['a', React.createRef()], ['z', React.createRef()]]
+    })
+    const { getByText } = root
+    expect(getByText('A'))
+    expect(getByText('Z'))
+  })
+})

--- a/src/components/ContentResult.spec.jsx
+++ b/src/components/ContentResult.spec.jsx
@@ -122,10 +122,10 @@ describe('ContentResult - search', () => {
     const { root } = setup()
     const searchValue = 'John'
 
-    const { queryByText, getByText, getByPlaceholderText } = root
+    const { queryByText, getAllByText, getByPlaceholderText } = root
 
-    // category of the contact
-    expect(getByText('EMPTY')).toBeTruthy()
+    // category of the contact + shortcuts by letter on the right
+    expect(getAllByText('EMPTY')).toBeTruthy()
 
     await search(searchValue, getByPlaceholderText)
 

--- a/src/components/ContentRework.spec.jsx
+++ b/src/components/ContentRework.spec.jsx
@@ -114,13 +114,13 @@ describe('ContentRework', () => {
     expect(getByTestId('contactSpinner'))
   })
 
-  it('should have empty section (for contacts without indexes) if service has been launched', () => {
+  it('should have empty section (for contacts without indexes) and corresponding shortcut on the right if service has been launched', () => {
     const { root } = setup()
-    const { getByText } = root
-    expect(getByText('EMPTY'))
+    const { getAllByText } = root
+    expect(getAllByText('EMPTY')).toHaveLength(2)
   })
 
-  it('should not have empty section (for contacts without indexes) if service has not been launched', () => {
+  it('should not have empty section (for contacts without indexes) nor corresponding shortcut on the right if service has not been launched', () => {
     const { root } = setup({
       hasServiceBeenLaunched: false
     })

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -70,3 +70,19 @@ main > [role=main]
 .contacts-empty>svg
     height 300px
     width 280px
+
+.categorized-list-wrapper
+    display flex
+    flex-direction row
+    .header-navigator
+        position sticky
+        top 0
+        align-self flex-start
+
+.header-navigator
+    list-style-type none
+    li
+        margin-top .2rem
+        text-align center
+        cursor pointer
+        color darkgray


### PR DESCRIPTION


Things that can be upgraded in future PRs:

- The bar containing the letters should fit the screen's height or be centered
- The current browsed letter should be highlighted
- Scrolling on the bar containing the letters with the mouse wheel should enable to navigate faster through the letters

![image](https://user-images.githubusercontent.com/1525665/143779807-7033ce77-f630-474b-bc84-edbe38354a81.png)

