### PR TITLE
feat: Add a navigation sidebar to jump directly to subheaders

### DIFF
--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -2,9 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import NavigationList, {
+  NavigationListHeader,
+  NavigationListSection
+} from 'cozy-ui/transpiled/react/NavigationList'
 import { Table } from 'cozy-ui/transpiled/react/Table'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 
 import ContactsSubList from './ContactsSubList'
 import { categorizeContacts } from '../../helpers/contactList'
@@ -13,15 +19,46 @@ const CategorizedList = ({ contacts }) => {
   const { t } = useI18n()
   const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
 
+  const categorizedContactsRefs = Object.fromEntries(
+    Object.keys(categorizedContacts).map(header => [header, React.createRef()])
+  )
+
+  const jumpToHeader = ref => {
+    ref.current.scrollIntoView(true)
+    ref.current.focus()
+  }
+
   return (
-    <Table>
-      {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <List key={`cat-${header}`}>
-          <ListSubheader key={header}>{header}</ListSubheader>
-          <ContactsSubList contacts={contacts} />
-        </List>
-      ))}
-    </Table>
+    <div className="categorized-list-wrapper">
+      <NavigationList className="categorized-list-navigation">
+        <NavigationListHeader>{t('jump')}</NavigationListHeader>
+        <NavigationListSection>
+          {Object.entries(categorizedContactsRefs).map(([header, ref]) => (
+            <ListItem
+              key={`jump-${header}`}
+              button
+              onClick={() => jumpToHeader(ref)}
+            >
+              <ListItemText primary={header} />
+            </ListItem>
+          ))}
+        </NavigationListSection>
+      </NavigationList>
+      <Table>
+        {Object.entries(categorizedContacts).map(([header, contacts]) => (
+          <List
+            key={`cat-${header}`}
+            ref={categorizedContactsRefs[header]}
+            tabIndex="-1"
+          >
+            <ListSubheader key={header} className="categorized-list-header">
+              {header}
+            </ListSubheader>
+            <ContactsSubList contacts={contacts} />
+          </List>
+        ))}
+      </Table>
+    </div>
   )
 }
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -16,6 +16,7 @@
   "me": "ich",
   "empty-list": "Leer",
   "search": "Suche",
+  "jump": "Zu Buchstabe gehen",
   "empty": {
     "title": "Deine Kontakte importieren",
     "title_filtered": "Kein Kontakt entspricht deiner Suche.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
   "me": "me",
   "empty-list": "EMPTY",
   "search": "Search",
+  "jump": "Go to the letter",
   "empty": {
     "title": "Import your contacts",
     "title_filtered": "No contact corresponds to your search.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -16,6 +16,7 @@
   "me": "yo",
   "empty-list": "VACIO",
   "search": "Busca",
+  "jump": "Ir a la letra",
   "empty": {
     "title": "Importar sus contactos",
     "title_filtered": "Ningún contacto corresponde a su búsqueda.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,6 +16,7 @@
   "me": "moi",
   "empty-list": "VIDE",
   "search": "Rechercher",
+  "jump": "Aller à la lettre",
   "empty": {
     "title": "Importer vos contacts",
     "title_filtered": "Aucun contact ne correspond à votre recherche.",

--- a/src/locales/nl_NL.json
+++ b/src/locales/nl_NL.json
@@ -16,6 +16,7 @@
   "me": "ik",
   "empty-list": "LEEG",
   "search": "Zoeken",
+  "jump": "Ga naar letter",
   "empty": {
     "title": "Contactpersonen importeren",
     "title_filtered": "Geen zoekresultaten.",

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -13,6 +13,26 @@ main > [role=main]
 .list-wrapper
     box-shadow 0 4px 4px 0 silver
 
+.categorized-list-wrapper
+    display flex
+    flex-direction row-reverse
+
+.categorized-list-navigation
+    position sticky
+    top 0
+    align-self start
+    max-height calc(100vh - 9rem)
+    padding .5rem
+    overflow auto
+
+    +medium-screen()
+        top 3rem
+        max-height calc(100vh - 3rem)
+
+.categorized-list-header
+    +medium-screen()
+        top 3rem
+
 .topbar
     display flex
     flex-shrink 0


### PR DESCRIPTION
Being able to scroll directly to a given letter is a common feature in contact apps.
This PR implements a proof of concept of such a feature by adding a scrolling navigation list in a sidebar, containing every initial letter found in the contact list.
This might be redundant with the search bar, but it might be useful especially on small devices, where it avoids opening the virtual keyboard to type.

Here is how it currently looks like:

![cozy-contacts-jump-to-header](https://user-images.githubusercontent.com/36267812/169507911-41579191-92bc-451c-ac36-f63f38b39015.png)

Reviews are welcome!
