### PR TITLE
feat : Contact quick scroll

### DIFF
--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -16,7 +16,7 @@ const CategorizedList = ({ contacts }) => {
   return (
     <Table>
       {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <List key={`cat-${header}`}>
+        <List key={`cat-${header}`} id={header}>
           <ListSubheader key={header}>{header}</ListSubheader>
           <ContactsSubList contacts={contacts} />
         </List>

--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -9,9 +9,15 @@ import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ContactsSubList from './ContactsSubList'
 import { categorizeContacts } from '../../helpers/contactList'
 
-const CategorizedList = ({ contacts }) => {
+const CategorizedList = ({ contacts, quickScrollLetter }) => {
   const { t } = useI18n()
   const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+
+  if (quickScrollLetter) {
+    document
+      .getElementById(quickScrollLetter)
+      .scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' })
+  }
 
   return (
     <Table>

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -11,7 +11,13 @@ import UncategorizedList from './UncategorizedList'
 import withSelection from '../Selection/selectionContainer'
 import SearchContext from '../Contexts/Search'
 
-const ContactsList = ({ contacts, clearSelection, selection, selectAll }) => {
+const ContactsList = ({
+  contacts,
+  quickScrollLetter,
+  clearSelection,
+  selection,
+  selectAll
+}) => {
   const { t } = useI18n()
   const { searchValue } = useContext(SearchContext)
 
@@ -37,13 +43,14 @@ const ContactsList = ({ contacts, clearSelection, selection, selectAll }) => {
           />
         </div>
       )}
-      <List contacts={contacts} />
+      <List contacts={contacts} quickScrollLetter={quickScrollLetter} />
     </div>
   )
 }
 
 ContactsList.propTypes = {
-  contacts: PropTypes.array.isRequired
+  contacts: PropTypes.array.isRequired,
+  quickScrollLetter: PropTypes.string
 }
 ContactsList.defaultProps = {}
 

--- a/src/components/ContactsList/ContactsQuickScroll.jsx
+++ b/src/components/ContactsList/ContactsQuickScroll.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import get from 'lodash/get'
+import Stack from 'cozy-ui/react/Stack'
+
+const scrollTo = letter => {
+  document.getElementById(letter).scrollIntoView()
+}
+
+const releaseEvent = event => {
+  event.target.releasePointerCapture(event.pointerId)
+}
+
+const ContactsQuickScroll = ({ contacts }) => {
+  const lettersList = contacts.map(c => {
+    return get(c, 'indexes.byFamilyNameGivenNameEmailCozyUrl', '').charAt(0)
+  })
+
+  const uniqueLettersList = [...new Set(lettersList)]
+
+  if (lettersList.length > 0) {
+    return (
+      <Stack spacing="xs" className="letter-selector">
+        {uniqueLettersList.map(l => (
+          <div
+            className="letter"
+            key={`Letter-${l}`}
+            onPointerEnter={() => scrollTo(l)}
+            onPointerDown={releaseEvent}
+          >
+            {l}
+          </div>
+        ))}
+      </Stack>
+    )
+  }
+}
+
+export default ContactsQuickScroll

--- a/src/components/ContactsList/ContactsQuickScroll.jsx
+++ b/src/components/ContactsList/ContactsQuickScroll.jsx
@@ -32,7 +32,7 @@ const ContactsQuickScroll = ({ contacts }) => {
 
   const uniqueLettersList = [...new Set(lettersList)]
 
-  if (lettersList.length > 0) {
+  if (uniqueLettersList.length > 0) {
     return (
       <Stack spacing="xs" className="letter-selector">
         {uniqueLettersList.map(l => (

--- a/src/components/ContactsList/ContactsQuickScroll.jsx
+++ b/src/components/ContactsList/ContactsQuickScroll.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import get from 'lodash/get'
 import Stack from 'cozy-ui/react/Stack'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import debounce from 'lodash/debounce'
 
 const releaseEvent = event => {
   event.target.releasePointerCapture(event.pointerId)
@@ -16,9 +17,14 @@ const ContactsQuickScroll = ({ contacts, onQuickScroll }) => {
     }
   }
 
+  const debouncedScroll = debounce(l => onQuickScroll(l), 500, {
+    leading: true,
+    trailing: false
+  });
+
   const scrollToOnPointerEnter = letter => {
     if (isMobile) {
-      onQuickScroll(letter)
+      debouncedScroll(letter)
     }
   }
 

--- a/src/components/ContactsList/ContactsQuickScroll.jsx
+++ b/src/components/ContactsList/ContactsQuickScroll.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import get from 'lodash/get'
 import Stack from 'cozy-ui/react/Stack'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 const scrollTo = letter => {
   document.getElementById(letter).scrollIntoView()
@@ -11,6 +12,20 @@ const releaseEvent = event => {
 }
 
 const ContactsQuickScroll = ({ contacts }) => {
+  const { isMobile } = useBreakpoints()
+
+  const scrollToOnClick = letter => {
+    if (!isMobile) {
+      scrollTo(letter)
+    }
+  }
+
+  const scrollToOnPointerEnter = letter => {
+    if (isMobile) {
+      scrollTo(letter)
+    }
+  }
+
   const lettersList = contacts.map(c => {
     return get(c, 'indexes.byFamilyNameGivenNameEmailCozyUrl', '').charAt(0)
   })
@@ -24,7 +39,8 @@ const ContactsQuickScroll = ({ contacts }) => {
           <div
             className="letter"
             key={`Letter-${l}`}
-            onPointerEnter={() => scrollTo(l)}
+            onClick={() => scrollToOnClick(l)}
+            onPointerEnter={() => scrollToOnPointerEnter(l)}
             onPointerDown={releaseEvent}
           >
             {l}

--- a/src/components/ContactsList/ContactsQuickScroll.jsx
+++ b/src/components/ContactsList/ContactsQuickScroll.jsx
@@ -3,26 +3,22 @@ import get from 'lodash/get'
 import Stack from 'cozy-ui/react/Stack'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-const scrollTo = letter => {
-  document.getElementById(letter).scrollIntoView()
-}
-
 const releaseEvent = event => {
   event.target.releasePointerCapture(event.pointerId)
 }
 
-const ContactsQuickScroll = ({ contacts }) => {
+const ContactsQuickScroll = ({ contacts, onQuickScroll }) => {
   const { isMobile } = useBreakpoints()
 
   const scrollToOnClick = letter => {
     if (!isMobile) {
-      scrollTo(letter)
+      onQuickScroll(letter)
     }
   }
 
   const scrollToOnPointerEnter = letter => {
     if (isMobile) {
-      scrollTo(letter)
+      onQuickScroll(letter)
     }
   }
 
@@ -48,6 +44,8 @@ const ContactsQuickScroll = ({ contacts }) => {
         ))}
       </Stack>
     )
+  } else {
+    return null
   }
 }
 

--- a/src/components/ContactsList/ContactsQuickScroll.jsx
+++ b/src/components/ContactsList/ContactsQuickScroll.jsx
@@ -20,7 +20,7 @@ const ContactsQuickScroll = ({ contacts, onQuickScroll }) => {
   const debouncedScroll = debounce(l => onQuickScroll(l), 500, {
     leading: true,
     trailing: false
-  });
+  })
 
   const scrollToOnPointerEnter = letter => {
     if (isMobile) {

--- a/src/components/ContactsList/ContactsQuickScroll.spec.js
+++ b/src/components/ContactsList/ContactsQuickScroll.spec.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import AppLike from '../../tests/Applike'
+import ContactsQuickScroll from './ContactsQuickScroll'
+
+const contacts = [
+  {
+    name: { familyName: 'A', givenName: 'John' },
+    email: [{ address: 'johnA@localhost' }],
+    indexes: { byFamilyNameGivenNameEmailCozyUrl: 'A' }
+  },
+  {
+    name: { familyName: 'B', givenName: 'John' },
+    email: [{ address: 'johnB@localhost' }],
+    indexes: { byFamilyNameGivenNameEmailCozyUrl: 'B' }
+  },
+  {
+    name: { familyName: 'C', givenName: 'John' },
+    email: [{ address: 'johnC@localhost' }],
+    indexes: { byFamilyNameGivenNameEmailCozyUrl: 'C' }
+  }
+]
+
+describe('ContactsQuickScroll', () => {
+  it('should not display without data', () => {
+    const contactsQuickScrollInstance = (
+      <AppLike>
+        <ContactsQuickScroll contacts={[]} />
+      </AppLike>
+    )
+    const contactsQuickScroll = mount(contactsQuickScrollInstance)
+    expect(contactsQuickScroll.text()).toBe('')
+  })
+
+  it('should display with data', () => {
+    const contactsQuickScrollInstance = (
+      <AppLike>
+        <ContactsQuickScroll contacts={contacts} />
+      </AppLike>
+    )
+    const contactsQuickScroll = mount(contactsQuickScrollInstance)
+    expect(contactsQuickScroll.find('.letter-selector > .letter'))
+      .toHaveLength(contacts.length)
+  })
+})

--- a/src/components/ContactsList/ContactsQuickScroll.spec.js
+++ b/src/components/ContactsList/ContactsQuickScroll.spec.js
@@ -40,7 +40,8 @@ describe('ContactsQuickScroll', () => {
       </AppLike>
     )
     const contactsQuickScroll = mount(contactsQuickScrollInstance)
-    expect(contactsQuickScroll.find('.letter-selector > .letter'))
-      .toHaveLength(contacts.length)
+    expect(contactsQuickScroll.find('.letter-selector > .letter')).toHaveLength(
+      contacts.length
+    )
   })
 })

--- a/src/components/ContentResult.jsx
+++ b/src/components/ContentResult.jsx
@@ -13,6 +13,7 @@ import SearchContext from './Contexts/Search'
 import Header from './Header'
 import Toolbar from './Toolbar'
 import ContactsList from './ContactsList/ContactsList.jsx'
+import ContactsQuickScroll from './ContactsList/ContactsQuickScroll.jsx'
 import GroupsSelect from './GroupsSelect/GroupsSelect'
 import SearchInput from './Search/SearchInput'
 import {
@@ -104,6 +105,7 @@ export const ContentResult = ({ contacts, allGroups }) => {
         />
       )}
       <Content>
+        <ContactsQuickScroll contacts={filteredContacts} />
         <ContactsList contacts={filteredContacts} />
       </Content>
     </>

--- a/src/components/ContentResult.jsx
+++ b/src/components/ContentResult.jsx
@@ -50,6 +50,7 @@ export const ContentResult = ({ contacts, allGroups }) => {
   const { selectedGroup, setSelectedGroup } = useContext(SelectedGroupContext)
   const { searchValue } = useContext(SearchContext)
   const [filteredContacts, setFilteredContacts] = useState(contacts)
+  const [quickScrollLetter, setQuickScrollLetter] = useState(null)
   const { isMobile } = useBreakpoints()
 
   const groupsSelectCustomStyles = setGroupsSelectCustomStyles(isMobile)
@@ -106,9 +107,15 @@ export const ContentResult = ({ contacts, allGroups }) => {
       )}
       <Content>
         {flag('contacts-quick-select') && (
-          <ContactsQuickScroll contacts={filteredContacts} />
+          <ContactsQuickScroll
+            contacts={filteredContacts}
+            onQuickScroll={setQuickScrollLetter}
+          />
         )}
-        <ContactsList contacts={filteredContacts} />
+        <ContactsList
+          contacts={filteredContacts}
+          quickScrollLetter={quickScrollLetter}
+        />
       </Content>
     </>
   )

--- a/src/components/ContentResult.jsx
+++ b/src/components/ContentResult.jsx
@@ -105,7 +105,9 @@ export const ContentResult = ({ contacts, allGroups }) => {
         />
       )}
       <Content>
-        <ContactsQuickScroll contacts={filteredContacts} />
+        {flag('contacts-quick-select') && (
+          <ContactsQuickScroll contacts={filteredContacts} />
+        )}
         <ContactsList contacts={filteredContacts} />
       </Content>
     </>

--- a/src/components/Hooks/useFlags.js
+++ b/src/components/Hooks/useFlags.js
@@ -6,6 +6,7 @@ const flagsList = () => {
   flag('logs')
   flag('select-all-contacts')
   flag('search-threshold')
+  flag('contacts-quick-select')
 }
 
 const initFlags = () => {

--- a/src/styles/contactsQuickScroll.styl
+++ b/src/styles/contactsQuickScroll.styl
@@ -1,6 +1,6 @@
 .letter-selector
     // Disable the blue hightlight on scroll
-    -webkit-tap-highlight-color: transparent;
+    -webkit-tap-highlight-color transparent
 
     z-index 2
     cursor pointer

--- a/src/styles/contactsQuickScroll.styl
+++ b/src/styles/contactsQuickScroll.styl
@@ -1,4 +1,7 @@
 .letter-selector
+    // Disable the blue hightlight on scroll
+    -webkit-tap-highlight-color: transparent;
+
     z-index 2
     cursor pointer
     position fixed

--- a/src/styles/contactsQuickScroll.styl
+++ b/src/styles/contactsQuickScroll.styl
@@ -1,0 +1,15 @@
+.letter-selector
+    z-index 2
+    cursor pointer
+    position fixed
+    right 0
+    top 50%
+    transform translate(0, -50%)
+    touch-action none
+    text-align center
+    padding 10px 0
+
+    .letter
+        opacity .5
+        touch-action none
+        padding 0 15px

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -5,6 +5,7 @@
 @require './contactGroups.styl'
 @require './contactImportation.styl'
 @require './contactGroupCreation.styl'
+@require './contactsQuickScroll.styl'
 
 [aria-hidden=true]
     display initial


### PR DESCRIPTION
Quick scroll component to navigate directly to a subheader of the `CategorizedList`.

- It needs the `contacts-quick-select` to be enabled.
- It works differently on mobile and desktop.
- The list does only contain the needed letters.