### PR TITLE
feat: category link

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/src/components/ContactsList/CategorizedList.jsx
+++ b/src/components/ContactsList/CategorizedList.jsx
@@ -8,20 +8,24 @@ import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 
 import ContactsSubList from './ContactsSubList'
 import { categorizeContacts } from '../../helpers/contactList'
+import CategoryLink from './CategoryLink'
 
 const CategorizedList = ({ contacts }) => {
   const { t } = useI18n()
   const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
 
   return (
-    <Table>
-      {Object.entries(categorizedContacts).map(([header, contacts]) => (
-        <List key={`cat-${header}`}>
-          <ListSubheader key={header}>{header}</ListSubheader>
-          <ContactsSubList contacts={contacts} />
-        </List>
-      ))}
-    </Table>
+    <>
+      <CategoryLink categories={Object.keys(categorizedContacts)} />
+      <Table>
+        {Object.entries(categorizedContacts).map(([header, contacts]) => (
+          <List key={`cat-${header}`} id={`cat-${header}`}>
+            <ListSubheader key={header}>{header}</ListSubheader>
+            <ContactsSubList contacts={contacts} />
+          </List>
+        ))}
+      </Table>
+    </>
   )
 }
 

--- a/src/components/ContactsList/CategoryLink.jsx
+++ b/src/components/ContactsList/CategoryLink.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import CategoryLinkItem from './CategoryLinkItem'
+
+const CategoryLink = ({ categories }) => {
+  return (
+    <div className="category-link">
+      {categories.map(category => (
+        <CategoryLinkItem key={`link-cat-${category}`} category={category} />
+      ))}
+    </div>
+  )
+}
+
+CategoryLink.propTypes = {
+  categories: PropTypes.array.isRequired
+}
+
+export default React.memo(CategoryLink)

--- a/src/components/ContactsList/CategoryLinkItem.jsx
+++ b/src/components/ContactsList/CategoryLinkItem.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Chips from 'cozy-ui/transpiled/react/Chips'
+
+const CategoryLinkItem = ({ category }) => {
+  const scrollTo = e => {
+    e.preventDefault() // Stop Page Reloading
+    let categoryElement = document.getElementById(`cat-${category}`)
+    categoryElement &&
+      categoryElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  return (
+    <Chips
+      sx={{ margin: '10px' }}
+      label={category.toUpperCase()}
+      onClick={scrollTo}
+    />
+  )
+}
+
+CategoryLinkItem.propTypes = {
+  category: PropTypes.string.isRequired
+}
+
+export default React.memo(CategoryLinkItem)

--- a/src/components/ContentResult.spec.jsx
+++ b/src/components/ContentResult.spec.jsx
@@ -122,10 +122,10 @@ describe('ContentResult - search', () => {
     const { root } = setup()
     const searchValue = 'John'
 
-    const { queryByText, getByText, getByPlaceholderText } = root
+    const { queryByText, getAllByText, getByPlaceholderText } = root
 
     // category of the contact
-    expect(getByText('EMPTY')).toBeTruthy()
+    expect(getAllByText('EMPTY')).toBeTruthy()
 
     await search(searchValue, getByPlaceholderText)
 

--- a/src/components/ContentRework.spec.jsx
+++ b/src/components/ContentRework.spec.jsx
@@ -116,8 +116,8 @@ describe('ContentRework', () => {
 
   it('should have empty section (for contacts without indexes) if service has been launched', () => {
     const { root } = setup()
-    const { getByText } = root
-    expect(getByText('EMPTY'))
+    const { getAllByText } = root
+    expect(getAllByText('EMPTY'))
   })
 
   it('should not have empty section (for contacts without indexes) if service has not been launched', () => {

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -51,3 +51,16 @@ main > [role=main]
     &>svg
         height 300px
         width 280px
+
+.category-link
+    display flex
+    padding-bottom 1rem
+    overflow auto hidden
+
+    +small-screen()
+        padding-left 1rem
+        padding-right 1 rem
+
+    .MuiChip-root-31
+        margin-left 0.25rem
+        margin-right 0.25rem

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -59,8 +59,8 @@ main > [role=main]
 
     +small-screen()
         padding-left 1rem
-        padding-right 1 rem
+        padding-right 1rem
 
     .MuiChip-root-31
-        margin-left 0.25rem
-        margin-right 0.25rem
+        margin-left .25rem
+        margin-right .25rem


### PR DESCRIPTION
This PR add category links on top of the categorised contact list. It's helping users navigate faster through their contacts. By clicking on the category link, you jump directly to category contact. 

On desktop : 
![Capture d’écran 2022-10-06 à 12 43 45](https://user-images.githubusercontent.com/7434420/194294893-1bcac4ef-6efd-4b30-8a1c-22e574bf4d72.png)

On mobile : 
![Capture d’écran 2022-10-06 à 12 44 51](https://user-images.githubusercontent.com/7434420/194294860-80c2622e-a35d-4e53-9163-bede88f12b21.png)