### PR TITLE
fix: Groups took time to delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "classnames": "2.3.1",
     "cozy-app-publish": "^0.29.0",
     "cozy-bar": "7.17.9",
-    "cozy-client": "^34.0.1",
+    "cozy-client": "^34.1.3",
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "^1.83.7",
     "cozy-flags": "^2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4326,16 +4326,16 @@ cozy-client@^27.15.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^34.0.1:
-  version "34.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.0.1.tgz#889977fe92ab7c34c65db992a9342e281971a415"
-  integrity sha512-HzN0tLPjRI+yI4a2Qgp5iwkfvHi3LH1zc2iaUP0wn4G+vZkznPMA+LIzrb9Rsx5MPg2IJMEmRS+NouW5I2yV+w==
+cozy-client@^34.1.3:
+  version "34.1.3"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.1.3.tgz#ec837324e7a0a21eac71e0353913e08d79e986d3"
+  integrity sha512-C01uou5RS7zioHPWnu4F/7jMxef4ODRd5uIb9zAEpaj6EeWsPLjXlmMb6lmv/ZlOCnKispJKwNVqgnAZh0greQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^34.0.0"
+    cozy-stack-client "^34.1.2"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -4652,10 +4652,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^34.0.0:
-  version "34.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.0.0.tgz#f60ed6fd6337ec21ac9a11e6b0d1cf660287975e"
-  integrity sha512-kn03m7cqgEB8FHXOktCuchvPOzrHmYH4lcL2E7iK0K1dAcjP8mB/q0LEx0xKmjEQVZS6dFUM5IFyR/AeJgG1Iw==
+cozy-stack-client@^34.1.2:
+  version "34.1.2"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.1.2.tgz#0dcbf0cd4162415ee63bc616d9be5668acf6be57"
+  integrity sha512-YXlhpIdKWmY8SZe98ahoOR6mCU6oLZPEPeCBljaI40peOOe95wZLCnHjQGL4JX2wueCO/CzmszU0QFcwzfdmIA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
In https://github.com/cozy/cozy-contacts/pull/893, I changed a _.where_ to a _.partialIndex_, and now when you click on the bin to delete a group, it disappears after 3s instead of 0s.

Adding a  _.where_ before the _.partialIndex_ fixes the problem and should not impact performance, but 
1. Do you know why ?
2. Is it a good fix ?

@paultranvan @Crash-- 