### PR TITLE
feat: Upgrade cozy-client to 34.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "classnames": "2.3.1",
     "cozy-app-publish": "^0.29.0",
     "cozy-bar": "7.17.9",
-    "cozy-client": "^34.1.3",
+    "cozy-client": "^34.3.0",
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "^1.83.7",
     "cozy-flags": "^2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4351,16 +4351,16 @@ cozy-client@^27.15.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^34.1.3:
-  version "34.1.3"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.1.3.tgz#ec837324e7a0a21eac71e0353913e08d79e986d3"
-  integrity sha512-C01uou5RS7zioHPWnu4F/7jMxef4ODRd5uIb9zAEpaj6EeWsPLjXlmMb6lmv/ZlOCnKispJKwNVqgnAZh0greQ==
+cozy-client@^34.3.0:
+  version "34.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.3.0.tgz#10a376e5a74046987d7b11e3c8cd2104b09c8d9a"
+  integrity sha512-yIKXVJZa6Vjjc0i3+LsfNx6ada+ytZ1aoTu/JW8ryK/saBDMRaBRZ++0YbMXZ7Q1iI51xSkc5/ue+9c4VDOwpg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^34.1.2"
+    cozy-stack-client "^34.1.5"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -4677,10 +4677,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^34.1.2:
-  version "34.1.2"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.1.2.tgz#0dcbf0cd4162415ee63bc616d9be5668acf6be57"
-  integrity sha512-YXlhpIdKWmY8SZe98ahoOR6mCU6oLZPEPeCBljaI40peOOe95wZLCnHjQGL4JX2wueCO/CzmszU0QFcwzfdmIA==
+cozy-stack-client@^34.1.5:
+  version "34.1.5"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.1.5.tgz#28fbc22b72f6343d968d4899d91c70f0261252f4"
+  integrity sha512-i0GsaaHNI2XmXUncbNPzuFY+DDC4/io3m7mwCmhAFyI/REHPdqOi3Oo5Mb7Euuky4A6iZjAWn5t0F69itv3rvg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
```
### ✨ Features

* Upgrade cozy-client from 34.1.3 to 34.3.0
```

This upgrade aims to have fetchPolicies export also for node. 