### PR TITLE
fix: use AppLinker in contact import

### DIFF
--- a/src/components/Common/ImportDropdown.jsx
+++ b/src/components/Common/ImportDropdown.jsx
@@ -1,14 +1,17 @@
 import React, { useState, useRef } from 'react'
-
-import { useClient } from 'cozy-client'
 import { useNavigate } from 'react-router-dom'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
 import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import Button from 'cozy-ui/transpiled/react/Button'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
-import TeamIcon from 'cozy-ui/transpiled/react/Icons/Team'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
+import Button from 'cozy-ui/transpiled/react/Button'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Link from 'cozy-ui/transpiled/react/Link'
+import TeamIcon from 'cozy-ui/transpiled/react/Icons/Team'
+import { useClient } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
 import { getFilteredStoreUrl } from '../../helpers/store'
 
 const ImportDropdown = () => {
@@ -19,10 +22,6 @@ const ImportDropdown = () => {
   const [menuDisplayed, setMenuDisplayed] = useState(false)
   const showMenu = () => setMenuDisplayed(true)
   const hideMenu = () => setMenuDisplayed(false)
-
-  const goToStore = () => {
-    window.location = getFilteredStoreUrl(client)
-  }
 
   return (
     <>
@@ -49,12 +48,19 @@ const ImportDropdown = () => {
           >
             {t('import.vcard')}
           </ActionMenuItem>
-          <ActionMenuItem
-            left={<AppIcon app={'store'} className="u-h-1 u-w-1" />}
-            onClick={goToStore}
-          >
-            {t('import.store')}
-          </ActionMenuItem>
+
+          <AppLinker app={{ slug: 'store' }} href={getFilteredStoreUrl(client)}>
+            {({ onClick, href }) => (
+              <ActionMenuItem
+                left={<AppIcon app={'store'} className="u-h-1 u-w-1" />}
+                onClick={onClick}
+              >
+                <Link className="u-p-0" href={href}>
+                  {t('import.store')}
+                </Link>
+              </ActionMenuItem>
+            )}
+          </AppLinker>
         </ActionMenu>
       )}
     </>

--- a/src/helpers/store.js
+++ b/src/helpers/store.js
@@ -1,16 +1,18 @@
-import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker'
+import { generateWebLink } from 'cozy-client'
 
 import { DOCTYPE_CONTACTS } from './doctypes'
 
 /**
  * Returns the store application url filtered by konnector and Contacts doctype
+ *
  * @param {object} client - cozy client
  * @returns {string} Universal link to store application
  */
 export const getFilteredStoreUrl = client =>
-  generateUniversalLink({
+  generateWebLink({
     cozyUrl: client.getStackClient().uri,
+    hash: `discover/?type=konnector&doctype=${DOCTYPE_CONTACTS}`,
+    pathname: '/',
     slug: 'store',
-    subDomainType: client.getInstanceOptions().subdomain,
-    nativePath: `discover/?type=konnector&doctype=${DOCTYPE_CONTACTS}`
+    subDomainType: client.getInstanceOptions().subdomain
   })

--- a/src/helpers/store.spec.js
+++ b/src/helpers/store.spec.js
@@ -14,12 +14,10 @@ describe('getFilteredStoreUrl', () => {
       }
     })
 
-    const universalLink =
-      'https://links.mycozy.cloud/store/discover/?type=konnector&doctype=io.cozy.contacts'
     const nativePath = '#/discover/?type=konnector&doctype=io.cozy.contacts'
 
     const test = decodeURIComponent(getFilteredStoreUrl(client))
-    const expected = `${universalLink}&fallback=${protocol}://${subdomain}-store.${domain}/${nativePath}`
+    const expected = `${protocol}://${subdomain}-store.${domain}/${nativePath}`
 
     expect(test).toEqual(expected)
   })


### PR DESCRIPTION
It replaces legacy window.location and also handles native app.
Though the redirection doesn't work in local dev, because going
from http to https. I don't know if we want to handle that?



```
### 🔧 Bug

* Replace import contact action with an Applinker for better multi-platform behaviour
```
