### PR TITLE
Add identities to Contact

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -37,6 +37,10 @@
       "type": "io.cozy.apps",
       "verbs": ["GET"]
     },
+    "identities": {
+      "type": "io.cozy.identities",
+      "verbs": ["GET"]
+    },
     "contacts": {
       "type": "io.cozy.contacts",
       "verbs": ["ALL"]

--- a/src/components/Modals/ContactFormModal.jsx
+++ b/src/components/Modals/ContactFormModal.jsx
@@ -7,12 +7,16 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import { buildContactsQueryById } from '../../queries/queries'
+import {
+  buildContactsQueryById,
+  buildIdentitiesQueryByContact
+} from '../../queries/queries'
 import SelectedGroupContext from '../../components/Contexts/SelectedGroup'
 import ContactForm, {
   getSubmitContactForm
 } from '../../components/ContactCard/ContactForm'
 import { createOrUpdateContact } from '../../connections/allContacts'
+import { makeContactWithIdentitiesAddresses } from '../../helpers/contacts'
 
 const ContactFormModal = () => {
   const navigate = useNavigate()
@@ -29,6 +33,16 @@ const ContactFormModal = () => {
   const { data: contact } = useQuery(
     contactsQueryById.definition,
     contactsQueryById.options
+  )
+
+  const isContactsQueryEnabled =
+    contact && contact.me && contact.address?.length === 0
+  const indentitiesContactsQueryById = buildIdentitiesQueryByContact(
+    isContactsQueryEnabled
+  )
+  const { data: identities } = useQuery(
+    indentitiesContactsQueryById.definition,
+    indentitiesContactsQueryById.options
   )
 
   const triggerFormSubmit = event => {
@@ -56,6 +70,11 @@ const ContactFormModal = () => {
     }
   }
 
+  const contactWithIdentitiesAddresses = makeContactWithIdentitiesAddresses(
+    contact,
+    identities
+  )
+
   return (
     <FixedDialog
       open
@@ -64,7 +83,7 @@ const ContactFormModal = () => {
       title={contact ? t('edit-contact') : t('create_contact')}
       content={
         <ContactForm
-          contact={contactWithNewData || contact}
+          contact={contactWithNewData || contactWithIdentitiesAddresses}
           onSubmit={handleFormSubmit}
         />
       }

--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -224,3 +224,12 @@ export const makeFormattedAddressWithSubFields = (subFieldsState, t) => {
 
   return cleanFormattedAddress(t('formatted.address', normalizedAddress))
 }
+
+export const makeContactWithIdentitiesAddresses = (contact, identities) => {
+  if (!identities || !contact.me || contact.address?.length > 0) return contact
+
+  return {
+    ...contact,
+    address: identities[0]?.contact?.address || contact?.address || []
+  }
+}

--- a/src/helpers/contacts.spec.js
+++ b/src/helpers/contacts.spec.js
@@ -6,7 +6,8 @@ import {
   harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl,
   reworkContacts,
   makeFormattedAddressWithSubFields,
-  getFormattedAddress
+  getFormattedAddress,
+  makeContactWithIdentitiesAddresses
 } from './contacts'
 import { johnDoeContact } from './testData'
 
@@ -447,5 +448,102 @@ describe('makeFormattedAddressWithSubFields', () => {
     )
 
     expect(res).toBe('')
+  })
+})
+
+describe('makeContactWithIdentitiesAddresses', () => {
+  it('should return the same contact if it has at least one address', () => {
+    const contactMock = {
+      ...johnDoeContact,
+      me: true,
+      address: [
+        {
+          formattedAddress: '94 Hinton Road 05034 Fresno, Singapore',
+          postcode: '05034',
+          city: 'Singapore'
+        }
+      ]
+    }
+    const identitiesMock = [
+      { contact: { address: [{ city: 'Cambridge', postcode: '16862' }] } }
+    ]
+    const res = makeContactWithIdentitiesAddresses(contactMock, identitiesMock)
+
+    expect(res).toBe(contactMock)
+  })
+
+  it('should return the same contact if `identitites` param is falsy', () => {
+    const contactMock = {
+      ...johnDoeContact,
+      me: true,
+      address: [
+        {
+          formattedAddress: '94 Hinton Road 05034 Fresno, Singapore',
+          postcode: '05034',
+          city: 'Singapore'
+        }
+      ]
+    }
+    const identitiesMock = undefined
+    const res = makeContactWithIdentitiesAddresses(contactMock, identitiesMock)
+
+    expect(res).toBe(contactMock)
+  })
+
+  it('should return the contact with the addresses in "identities" if it does not have one itself', () => {
+    const contactMock = {
+      ...johnDoeContact,
+      me: true,
+      address: []
+    }
+    const identitiesMock = [
+      { contact: { address: [{ city: 'Cambridge', postcode: '16862' }] } }
+    ]
+
+    const expected = {
+      ...johnDoeContact,
+      me: true,
+      address: [{ city: 'Cambridge', postcode: '16862' }]
+    }
+
+    const res = makeContactWithIdentitiesAddresses(contactMock, identitiesMock)
+
+    expect(res).toStrictEqual(expected)
+  })
+
+  it('should return the same contact if has no addresses and the "me" attribut is falsy', () => {
+    const contactMock = {
+      ...johnDoeContact,
+      me: false,
+      address: []
+    }
+    const identitiesMock = [
+      { contact: { address: [{ city: 'Cambridge', postcode: '16862' }] } }
+    ]
+
+    const res = makeContactWithIdentitiesAddresses(contactMock, identitiesMock)
+
+    expect(res).toStrictEqual(contactMock)
+  })
+
+  it('should return the same contact if it has at least one address and the "me" attribut is falsy', () => {
+    const contactMock = {
+      ...johnDoeContact,
+      me: false,
+      address: [
+        {
+          formattedAddress: '94 Hinton Road 05034 Fresno, Singapore',
+          postcode: '05034',
+          city: 'Singapore'
+        }
+      ]
+    }
+    const identitiesMock = [
+      { contact: { address: [{ city: 'Cambridge', postcode: '16862' }] } }
+    ]
+
+    const res = makeContactWithIdentitiesAddresses(contactMock, identitiesMock)
+
+    expect(res).toStrictEqual(contactMock)
   })
 })

--- a/src/helpers/doctypes.js
+++ b/src/helpers/doctypes.js
@@ -3,6 +3,7 @@ export const DOCTYPE_CONTACTS_VERSION = 3
 export const DOCTYPE_CONTACT_GROUPS = 'io.cozy.contacts.groups'
 export const DOCTYPE_CONTACT_ACCOUNTS = 'io.cozy.contacts.accounts'
 export const DOCTYPE_TRIGGERS = 'io.cozy.triggers'
+export const DOCTYPE_IDENTITIES = 'io.cozy.identities'
 export const schema = {
   contacts: {
     doctype: DOCTYPE_CONTACTS,

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -2,6 +2,7 @@ import { Q, fetchPolicies } from 'cozy-client'
 import {
   DOCTYPE_CONTACTS,
   DOCTYPE_CONTACT_GROUPS,
+  DOCTYPE_IDENTITIES,
   DOCTYPE_TRIGGERS
 } from '../helpers/doctypes'
 
@@ -18,6 +19,15 @@ export const buildContactsQueryById = id => ({
     fetchPolicy: fetchPolicies.olderThan(older30s),
     singleDocData: true,
     enabled: Boolean(id)
+  }
+})
+
+export const buildIdentitiesQueryByContact = (enabled = false) => ({
+  definition: Q(DOCTYPE_IDENTITIES),
+  options: {
+    as: DOCTYPE_IDENTITIES,
+    fetchPolicy: fetchPolicies.olderThan(older30s),
+    enabled
   }
 })
 


### PR DESCRIPTION
Cette PR ajoute la possibilité de remplir les champs du formulaire avec les données trouvées dans `io.cozy.identities`, à la condition que le contact n'ait pas d'adresse.
Ainsi pour cette première itération, nous évitons toutes incohérences dans les adresses.

```
### ✨ Features

* Add addresses from a connector to the contact, if not filled in
```
