### PR TITLE
Feat/use cozy minilog instead cozy logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@sentry/react": "7.54.0",
+    "@sentry/integrations": "7.88.0",
+    "@sentry/react": "7.88.0",
     "classnames": "2.3.1",
     "cozy-bar": "7.17.9",
     "cozy-client": "^40.0.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "cozy-flags": "^2.11.0",
     "cozy-harvest-lib": "^13.2.1",
     "cozy-intent": "^2.8.0",
-    "cozy-logger": "^1.10.0",
+    "cozy-minilog": "^3.3.1",
     "cozy-realtime": "^4.3.0",
     "cozy-sharing": "^6.0.3",
     "cozy-ui": "^95.1.0",

--- a/src/components/Hooks/useService.jsx
+++ b/src/components/Hooks/useService.jsx
@@ -2,10 +2,12 @@ import get from 'lodash/get'
 import { useState, useCallback, useEffect } from 'react'
 
 import { useClient } from 'cozy-client'
-import log from 'cozy-logger'
+import minilog from 'cozy-minilog'
 
 import { DOCTYPE_TRIGGERS } from '../../helpers/doctypes'
 import { fetchNormalizedServiceByName } from '../../helpers/fetches'
+
+const log = minilog('useService')
 
 const hasServiceBeenLaunched = service => {
   return get(service, 'current_state.last_success', '').length > 0
@@ -28,7 +30,7 @@ const useService = name => {
   useEffect(() => {
     // start service if it has never been launched before
     if (service && hasBeenLaunched === false) {
-      log('info', `Executing ${name} service by Contacts app`)
+      log.info(`Executing ${name} service by Contacts app`)
       client.collection(DOCTYPE_TRIGGERS).launch(service)
     }
   }, [service, client, hasBeenLaunched, name])

--- a/src/components/Modals/ContactInfoTitle.jsx
+++ b/src/components/Modals/ContactInfoTitle.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import log from 'cozy-logger'
+import minilog from 'cozy-minilog'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Grid from 'cozy-ui/transpiled/react/Grid'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -17,6 +17,8 @@ import ContactIdentity from '../ContactCard/ContactIdentity'
 import { fullContactPropTypes } from '../ContactPropTypes'
 import GroupsSelect from '../GroupsSelect/GroupsSelect'
 import Control from '../GroupsSelect/SelectBox/Control'
+
+const log = minilog('ContactInfoTitle')
 
 const customStyles = {
   container: base => ({
@@ -46,7 +48,7 @@ const ContactInfoTitle = ({ contact, allGroups }) => {
       await updateContactGroups(contact, nextGroups)
     } catch (error) {
       Alerter.success('error.group_selected')
-      log('error', `There was a problem when selecting a group : ${error}`)
+      log.error('There was a problem when selecting a group', error)
     }
   }
 

--- a/src/connections/allContacts.js
+++ b/src/connections/allContacts.js
@@ -2,7 +2,7 @@ import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 import uniqWith from 'lodash/uniqWith'
 
-import log from 'cozy-logger'
+import minilog from 'cozy-minilog'
 
 import { addGroupToContact } from '../helpers/contacts'
 import { DOCTYPE_CONTACTS } from '../helpers/doctypes'
@@ -13,6 +13,8 @@ import {
   buildContactsQueryByGroupId,
   buildContactsTrashedQuery
 } from '../queries/queries'
+
+const log = minilog('connections/allContacts')
 
 export const importContact = async (client, attributes) => {
   const addresses = (attributes['email'] || []).map(email => email.address)
@@ -193,9 +195,9 @@ export const trashedAllContactsByGroupId = async (client, groupId) => {
       const result = await client.saveAll(contactsTrashed)
       return result.data
     }
-    log('info', 'No contacts to trash')
+    log.info('No contacts to trash')
     return []
   } catch (error) {
-    log('error', `Error saving contact to trash: ${error}`)
+    log.error('Error saving contact to trash', error)
   }
 }

--- a/src/helpers/fetches.js
+++ b/src/helpers/fetches.js
@@ -1,6 +1,6 @@
 import isEqual from 'lodash/isEqual'
 
-import log from 'cozy-logger'
+import minilog from 'cozy-minilog'
 
 import { updateIndexFullNameAndDisplayName } from './contacts'
 import {
@@ -8,6 +8,8 @@ import {
   buildTriggersQueryById,
   buildContactsQueryByUpdatedAtGT
 } from '../queries/queries'
+
+const log = minilog('helpers/fetches')
 
 /**
  * Fetches and returns a promise of contacts to update according to this :
@@ -33,7 +35,7 @@ export const fetchContactsToUpdate = async (client, date) => {
       if (!isEqual(contact, expected[index])) return contacts.push(contact)
     })
 
-    log('info', `found ${contacts.length} contact(s) to update`)
+    log.info(`found ${contacts.length} contact(s) to update`)
 
     return contacts
   } catch (e) {
@@ -65,7 +67,7 @@ export const fetchNormalizedServiceByName = async (client, serviceName) => {
 
     return normalizedTrigger.data
   } catch (e) {
-    log('error', `Can't find ${serviceName}: ${e}`)
+    log.error("Can't find:", serviceName, e)
     return null
   }
 }

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -1,4 +1,4 @@
-/* global __DEVELOPMENT__ */
+import { CaptureConsole } from '@sentry/integrations'
 import * as Sentry from '@sentry/react'
 import memoize from 'lodash/memoize'
 import { createRoot } from 'react-dom/client'
@@ -39,10 +39,15 @@ const setupApp = memoize(() => {
 
   Sentry.init({
     dsn: 'https://0db57f6ff6384bb3af8102f76bc01262@errors.cozycloud.cc/62',
-    environment: __DEVELOPMENT__,
+    environment: process.env.NODE_ENV,
     release: manifest.version,
-    integrations: [new Sentry.BrowserTracing()],
-    tracesSampleRate: 0.35
+    integrations: [
+      new CaptureConsole({ levels: ['error'] }), // We also want to capture the `console.error` to, among other things, report the logs present in the `try/catch`
+      new Sentry.BrowserTracing()
+    ],
+    tracesSampleRate: 1,
+    // React log these warnings(bad Proptypes), in a console.error, it is not relevant to report this type of information to Sentry
+    ignoreErrors: [/^Warning: /]
   })
 
   initBar({ client, container, lang, appName })

--- a/src/targets/services/keepIndexFullNameAndDisplayNameUpToDate.js
+++ b/src/targets/services/keepIndexFullNameAndDisplayNameUpToDate.js
@@ -2,7 +2,7 @@ import omit from 'lodash/omit'
 import fetch from 'node-fetch'
 
 import CozyClient from 'cozy-client'
-import log from 'cozy-logger'
+import minilog from 'cozy-minilog'
 
 import { updateIndexFullNameAndDisplayName } from '../../helpers/contacts'
 import { schema, DOCTYPE_CONTACTS } from '../../helpers/doctypes'
@@ -12,9 +12,10 @@ import {
 } from '../../helpers/fetches'
 
 global.fetch = fetch
+const log = minilog('services/keepIndexFullNameAndDisplayNameUpToDate')
 
 export const keepIndexFullNameAndDisplayNameUpToDate = async () => {
-  log('info', `Executing keepIndexFullNameAndDisplayNameUpToDate service`)
+  log.info(`Executing keepIndexFullNameAndDisplayNameUpToDate service`)
   const client = CozyClient.fromEnv(process.env, { schema })
 
   const normalizedService = await fetchNormalizedServiceByName(
@@ -33,10 +34,10 @@ export const keepIndexFullNameAndDisplayNameUpToDate = async () => {
   )
   await client.collection(DOCTYPE_CONTACTS).updateAll(updatedContactsToUpload)
   updatedContactsToUpload.length &&
-    log('info', `All contacts successfully updated`)
+    log.info('All contacts successfully updated')
 }
 
 keepIndexFullNameAndDisplayNameUpToDate().catch(e => {
-  log('critical', e)
+  log.error(e)
   process.exit(1)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,27 +2337,35 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.2.tgz#58cd2bd25df2acc16c628e1b6f6150ea6c7455bc"
   integrity sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==
 
-"@sentry-internal/tracing@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.54.0.tgz#eeb10ee72426d08669a7706faa4264f1ec02c71d"
-  integrity sha512-JsyhZ0wWZ+VqbHJg+azqRGdYJDkcI5R9+pnkO6SzbzxrRewqMAIwzkpPee3oI7vG99uhMEkOkMjHu0nQGwkOQw==
+"@sentry-internal/feedback@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.88.0.tgz#fa4db4a27d1fa7fe51dc67af185b13519d7fbc76"
+  integrity sha512-lbK6jgO1I0M96nZQ99mcLSZ55ebwPAP6LhEWhkmc+eAfy97VpiY+qsbmgsmOzCEPqMmEUCEcI0rEZ7fiye2v2Q==
   dependencies:
-    "@sentry/core" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
-    tslib "^1.9.3"
+    "@sentry/core" "7.88.0"
+    "@sentry/types" "7.88.0"
+    "@sentry/utils" "7.88.0"
 
-"@sentry/browser@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.54.0.tgz#7fe331c776d02b5c902733aa41dcbfac7bef1ae6"
-  integrity sha512-EvLAw03N9WE2m1CMl2/1YMeIs1icw9IEOVJhWmf3uJEysNJOFWXu6ZzdtHEz1E6DiJYhc1HzDya0ExZeJxNARA==
+"@sentry-internal/tracing@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.88.0.tgz#c820bde835c4af576781f8b818eed5085e417927"
+  integrity sha512-xXQdcYhsS+ourzJHjXNjZC9zakuc97udmpgaXRjEP7FjPYclIx+YXwgFBdHM2kzAwZLFOsEce5dr46GVXUDfZw==
   dependencies:
-    "@sentry-internal/tracing" "7.54.0"
-    "@sentry/core" "7.54.0"
-    "@sentry/replay" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
-    tslib "^1.9.3"
+    "@sentry/core" "7.88.0"
+    "@sentry/types" "7.88.0"
+    "@sentry/utils" "7.88.0"
+
+"@sentry/browser@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.88.0.tgz#80e3afe00e19bffbed09be392061e64dd6196796"
+  integrity sha512-il4x3PB99nuU/OJQw2RltgYYbo8vtnYoIgneOeEiw4m0ppK1nKkMkd3vDRipGL6E/0i7IUmQfYYy6U10J5Rx+g==
+  dependencies:
+    "@sentry-internal/feedback" "7.88.0"
+    "@sentry-internal/tracing" "7.88.0"
+    "@sentry/core" "7.88.0"
+    "@sentry/replay" "7.88.0"
+    "@sentry/types" "7.88.0"
+    "@sentry/utils" "7.88.0"
 
 "@sentry/browser@^6.0.1":
   version "6.19.7"
@@ -2380,14 +2388,13 @@
     "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/core@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.54.0.tgz#8c4cb8800f8df708b3f3f6483026bb9a02820014"
-  integrity sha512-MAn0E2EwgNn1pFQn4qxhU+1kz6edullWg6VE5wCmtpXWOVw6sILBUsQpeIG5djBKMcneJCdOlz5jeqcKPrLvZQ==
+"@sentry/core@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.88.0.tgz#46f1526e9b98de96a0e93fd69917a990db5d5a37"
+  integrity sha512-Jzbb7dcwiCO7kI0a1w+32UzWxbEn2OcZWzp55QMEeAh6nZ/5CXhXwpuHi0tW7doPj+cJdmxMTMu9LqMVfdGkzQ==
   dependencies:
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
-    tslib "^1.9.3"
+    "@sentry/types" "7.88.0"
+    "@sentry/utils" "7.88.0"
 
 "@sentry/hub@6.19.7":
   version "6.19.7"
@@ -2398,6 +2405,16 @@
     "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
+"@sentry/integrations@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.88.0.tgz#38179405ff6673a9526cebbea656c7c6c69ccd06"
+  integrity sha512-YBYPAtJeylMaaCmGntgiDpp1nk3IT6+FBXsmHxMdTKlrpt5ELj/jcc8gEgaRNeSBjx4Kv1OVzmZcYyWwEhkR4Q==
+  dependencies:
+    "@sentry/core" "7.88.0"
+    "@sentry/types" "7.88.0"
+    "@sentry/utils" "7.88.0"
+    localforage "^1.8.1"
+
 "@sentry/minimal@6.19.7":
   version "6.19.7"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.7.tgz#b3ee46d6abef9ef3dd4837ebcb6bdfd01b9aa7b4"
@@ -2407,35 +2424,35 @@
     "@sentry/types" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/react@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.54.0.tgz#0d9e1b902fd9ded713ac46a623f6a490e4aa2c8a"
-  integrity sha512-qUbwmRRpTh05m2rbC8A2zAFQYsoHhwIpxT5UXxh0P64ZlA3cSg1/DmTTgwnd1l+7gzKrc31UikXQ4y0YDbMNKg==
+"@sentry/react@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.88.0.tgz#3913b3d81b6d06ef9f58e4c7d53f32ad1b4d31cb"
+  integrity sha512-iDOImijbsc0cYLWNBXlYKhh/sG/czPK/51GcMi3GcEBkhHDDcdWSZ7cNjFAqHfdrMkPf26bYgDPIL6aJsBZwpQ==
   dependencies:
-    "@sentry/browser" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
+    "@sentry/browser" "7.88.0"
+    "@sentry/types" "7.88.0"
+    "@sentry/utils" "7.88.0"
     hoist-non-react-statics "^3.3.2"
-    tslib "^1.9.3"
 
-"@sentry/replay@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.54.0.tgz#f0f44f9413ceefd1809bf1665e82315927ae08db"
-  integrity sha512-C0F0568ybphzGmKGe23duB6n5wJcgM7WLYhoeqW3o2bHeqpj1dGPSka/K3s9KzGaAgzn1zeOUYXJsOs+T/XdsA==
+"@sentry/replay@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.88.0.tgz#a9158af527db0cce91659f9a87b938040c21fdaa"
+  integrity sha512-em5dPKLPG7c/HGDbpIj3aHrWbA4iMwqjevqTzn+++KNO1YslkOosCaGsb1whU3AL1T9c3aIFIhZ4u3rNo+DxcA==
   dependencies:
-    "@sentry/core" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
+    "@sentry-internal/tracing" "7.88.0"
+    "@sentry/core" "7.88.0"
+    "@sentry/types" "7.88.0"
+    "@sentry/utils" "7.88.0"
 
 "@sentry/types@6.19.7":
   version "6.19.7"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
   integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
 
-"@sentry/types@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.54.0.tgz#bfee18107a78e290e6c8ad41646e2b9d9dd95234"
-  integrity sha512-D+i9xogBeawvQi2r0NOrM7zYcUaPuijeME4O9eOTrDF20tj71hWtJLilK+KTGLYFtpGg1h+9bPaz7OHEIyVopg==
+"@sentry/types@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.88.0.tgz#b3a09733a7bfad3634687b77764c5767d646d6e7"
+  integrity sha512-FvwvmX1pWAZKicPj4EpKyho8Wm+C4+r5LiepbbBF8oKwSPJdD2QV1fo/LWxsrzNxWOllFIVIXF5Ed3nPYQWpTw==
 
 "@sentry/utils@6.19.7":
   version "6.19.7"
@@ -2445,13 +2462,12 @@
     "@sentry/types" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/utils@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.54.0.tgz#a3acb5e25a1409cbca7b46d6356d7417a253ea9a"
-  integrity sha512-3Yf5KlKjIcYLddOexSt2ovu2TWlR4Fi7M+aCK8yUTzwNzf/xwFSWOstHlD/WiDy9HvfhWAOB/ukNTuAeJmtasw==
+"@sentry/utils@7.88.0":
+  version "7.88.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.88.0.tgz#704e79f14047080564c3e5231028f1cef8824e9f"
+  integrity sha512-ukminfRmdBXTzk49orwJf3Lu3hR60ZRHjE2a4IXwYhyDT6JJgJqgsq1hzGXx0AyFfyS4WhfZ6QUBy7fu3BScZQ==
   dependencies:
-    "@sentry/types" "7.54.0"
-    tslib "^1.9.3"
+    "@sentry/types" "7.88.0"
 
 "@sinclair/typebox@^0.25.16":
   version "0.25.21"
@@ -10459,6 +10475,13 @@ localforage@1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.7.3.tgz#0082b3ca9734679e1bd534995bdd3b24cf10f204"
   integrity sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==
+  dependencies:
+    lie "3.1.1"
+
+localforage@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
   dependencies:
     lie "3.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5326,6 +5326,13 @@ cozy-logger@^1.10.0, cozy-logger@^1.3.0, cozy-logger@^1.6.0, cozy-logger@^1.8.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
+cozy-minilog@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-minilog/-/cozy-minilog-3.3.1.tgz#472dccf4a9391c479120a83d26b435cf9d609c72"
+  integrity sha512-NLQNQ1Q/bvJrqNv9w5bLjfAxYKv+pESobJgUKXondxP616kx7k0mpiRrCZBaJRbEbpKryT/eJ0JJwLdVaIP5NA==
+  dependencies:
+    microee "0.0.6"
+
 cozy-realtime@^4.0.5, cozy-realtime@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-4.3.0.tgz#d5a37bd09910573248e2929a7ebfa4a5d8f4a97c"
@@ -11121,9 +11128,9 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
For purposes of improving logs in the browser but also in Sentry.
`cozy-logger` does not log errors, so Sentry couldn't intercept the log.

### ✨ Features

* Add cozy-minilog ^3.3.1, and remove cozy-logger

### 🔧 Tech

* Fix Sentry configuration
