### PR TITLE
fix: Correct order of contacts

### DIFF
--- a/src/helpers/contacts.js
+++ b/src/helpers/contacts.js
@@ -127,24 +127,35 @@ export const harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl = (
     updateIndexFullNameAndDisplayName(contact)
   )
   const concatedContacts = contactsWithIndexes.concat(updatedContacts)
-  const {
-    itemsFound: [mySelf],
-    remainingItems: contactsWithoutMySelf
-  } = filterWithRemaining(concatedContacts, contact => contact.me)
-  const sortedContacts = sortBy(contactsWithoutMySelf, [
+  const sortedContacts = sortBy(concatedContacts, [
     'indexes.byFamilyNameGivenNameEmailCozyUrl'
   ])
-  if (mySelf) sortedContacts.unshift(mySelf)
 
   return sortedContacts
 }
 
 /**
+ * Move myself to first position in contacts list
+ * @param {object[]} contacts - contacts list
+ * @returns {object[]}
+ */
+const moveMyselfToFirstPosition = contacts => {
+  const {
+    itemsFound: [mySelf],
+    remainingItems: contactsWithoutMySelf
+  } = filterWithRemaining(contacts, contact => contact.me)
+
+  if (mySelf) return [mySelf, ...contactsWithoutMySelf]
+
+  return contacts
+}
+
+/**
  * Sort and rework contacts according to 'keepIndexFullNameAndDisplayNameUpToDate' service status
  * @param {bool} hasServiceBeenLaunched - 'keepIndexFullNameAndDisplayNameUpToDate' service launch status
- * @param {array} contactsWithIndexes - Contacts with indexes
- * @param {array} contactsWithNoIndexes - Contacts without indexes
- * @returns {array} Sorted and harmonized contacts
+ * @param {object[]} contactsWithIndexes - Contacts with indexes
+ * @param {object[]} contactsWithNoIndexes - Contacts without indexes
+ * @returns {object[]} Sorted and harmonized contacts
  */
 export const reworkContacts = (
   hasServiceBeenLaunched,
@@ -152,11 +163,16 @@ export const reworkContacts = (
   contactsWithNoIndexes
 ) => {
   const reworkedContacts = hasServiceBeenLaunched
-    ? contactsWithIndexes.concat(contactsWithNoIndexes)
-    : harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl(
-        contactsWithIndexes,
-        contactsWithNoIndexes
+    ? moveMyselfToFirstPosition(
+        contactsWithIndexes.concat(contactsWithNoIndexes)
       )
+    : moveMyselfToFirstPosition(
+        harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl(
+          contactsWithIndexes,
+          contactsWithNoIndexes
+        )
+      )
+
   return reworkedContacts
 }
 

--- a/src/helpers/contacts.spec.js
+++ b/src/helpers/contacts.spec.js
@@ -164,7 +164,7 @@ describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
           familyName: 'Damon'
         },
         indexes: {
-          byFamilyNameGivenNameEmailCozyUrl: 'mattdamon'
+          byFamilyNameGivenNameEmailCozyUrl: 'damonmatt'
         }
       },
       {
@@ -173,16 +173,16 @@ describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
           familyName: 'Doe'
         },
         indexes: {
-          byFamilyNameGivenNameEmailCozyUrl: 'johndoe'
+          byFamilyNameGivenNameEmailCozyUrl: 'doejohn'
         }
       },
       {
         name: {
           givenName: 'Max',
-          familyName: 'Payne'
+          familyName: 'Abe'
         },
         indexes: {
-          byFamilyNameGivenNameEmailCozyUrl: 'maxpayne'
+          byFamilyNameGivenNameEmailCozyUrl: 'abemax'
         },
         me: true
       }
@@ -205,9 +205,9 @@ describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
 
     const expected = [
       {
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'maxpayne' },
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'abemax' },
         me: true,
-        name: { familyName: 'Payne', givenName: 'Max' }
+        name: { familyName: 'Abe', givenName: 'Max' }
       },
       {
         displayName: 'Anton Bradbury',
@@ -216,12 +216,12 @@ describe('harmonizeAndSortByFamilyNameGivenNameEmailCozyUrl', () => {
         indexes: { byFamilyNameGivenNameEmailCozyUrl: 'bradburyanton' }
       },
       {
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'johndoe' },
-        name: { familyName: 'Doe', givenName: 'John' }
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'damonmatt' },
+        name: { familyName: 'Damon', givenName: 'Matt' }
       },
       {
-        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'mattdamon' },
-        name: { familyName: 'Damon', givenName: 'Matt' }
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'doejohn' },
+        name: { familyName: 'Doe', givenName: 'John' }
       },
       {
         displayName: 'William Wallace',
@@ -252,6 +252,16 @@ describe('reworkContacts', () => {
         indexes: {
           byFamilyNameGivenNameEmailCozyUrl: 'mattdamon'
         }
+      },
+      {
+        name: {
+          givenName: 'Max',
+          familyName: 'Abe'
+        },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'maxabe'
+        },
+        me: true
       }
     ]
 
@@ -265,6 +275,16 @@ describe('reworkContacts', () => {
     ]
 
     const expected = [
+      {
+        name: {
+          givenName: 'Max',
+          familyName: 'Abe'
+        },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'maxabe'
+        },
+        me: true
+      },
       {
         displayName: 'Anton Bradbury',
         fullname: 'Anton Bradbury',
@@ -297,6 +317,16 @@ describe('reworkContacts', () => {
         indexes: {
           byFamilyNameGivenNameEmailCozyUrl: 'mattdamon'
         }
+      },
+      {
+        name: {
+          givenName: 'Max',
+          familyName: 'Abe'
+        },
+        indexes: {
+          byFamilyNameGivenNameEmailCozyUrl: 'maxabe'
+        },
+        me: true
       }
     ]
 
@@ -310,6 +340,11 @@ describe('reworkContacts', () => {
     ]
 
     const expected = [
+      {
+        indexes: { byFamilyNameGivenNameEmailCozyUrl: 'maxabe' },
+        me: true,
+        name: { familyName: 'Abe', givenName: 'Max' }
+      },
       {
         indexes: { byFamilyNameGivenNameEmailCozyUrl: 'mattdamon' },
         name: { familyName: 'Damon', givenName: 'Matt' }


### PR DESCRIPTION
We did a manual sort and put "me" first in contacts list if the service was never launched.
If the service has already been launched, we retrieve the contacts such as (because it is the query which does the asc sorting), but in this case we must also put "me" first.

