### PR TITLE
fix(Services): AutoDefineLabel should not modify existing correct contact

### DIFF
--- a/src/helpers/autoDefineLabelsService.js
+++ b/src/helpers/autoDefineLabelsService.js
@@ -33,18 +33,16 @@ export const updateAttributeWithLabel = (contact, attributeName) => {
   }
 
   const updatedAttr = values.map(el => {
-    if (!el.label) {
-      if (el.type) {
-        const normalizedType = el.type
-          ?.normalize('NFD')
-          .replace(/[\u0300-\u036f]/g, '')
-          .toLowerCase()
+    if (!el.label && el.type) {
+      const normalizedType = el.type
+        ?.normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
 
-        el.label = PRO_KEYWORDS[lang].includes(normalizedType) ? 'work' : 'home'
-      }
-
-      return el
+      el.label = PRO_KEYWORDS[lang].includes(normalizedType) ? 'work' : 'home'
     }
+
+    return el
   })
 
   return updatedAttr

--- a/src/helpers/autoDefineLabelsService.spec.js
+++ b/src/helpers/autoDefineLabelsService.spec.js
@@ -6,6 +6,26 @@ import {
 
 describe('updateAttributeWithLabel', () => {
   describe('for one value', () => {
+    it('should not modify anything if already have type and label', () => {
+      const res = updateAttributeWithLabel(
+        { address: [{ primary: true, type: 'custom', label: 'home' }] },
+        'address'
+      )
+
+      expect(res).toStrictEqual([
+        { primary: true, type: 'custom', label: 'home' }
+      ])
+    })
+
+    it('should not modify anything if already have label', () => {
+      const res = updateAttributeWithLabel(
+        { address: [{ primary: true, label: 'home' }] },
+        'address'
+      )
+
+      expect(res).toStrictEqual([{ primary: true, label: 'home' }])
+    })
+
     it('should not add the label if no type', () => {
       const res = updateAttributeWithLabel(
         { address: [{ primary: true }] },


### PR DESCRIPTION
Si un contact a déjà utilisé la nouvelle feature de libellé, il ne faut pas que le service le modifie.