### PR TITLE
fix: Move custom theme CSS at end of <head>

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link
       rel="icon"
@@ -39,6 +38,7 @@
       href="//{{.Domain}}/assets/fonts/fonts.css"
     />
     <% } %>
+    {{.ThemeCSS}}
   </head>
   <div
     role="application"

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link
       rel="icon"
@@ -32,6 +31,7 @@
     <link rel="stylesheet" href="<%- file %>" />
     <% }); %>
     {{.CozyClientJS}}
+    {{.ThemeCSS}}
   </head>
   <div
     role="application"


### PR DESCRIPTION
Our custom theme CSS was not taken into account because cozy-ui CSS was inserted after.

```
### 🐛 Bug Fixes

* Custom theme colors were not taken into account
```
