### PR TITLE
chore: Remove node_js in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: jammy
 language: node_js
-node_js: 20
 cache:
   npm: false
 env:


### PR DESCRIPTION
We will only take into account .nvmrc
