### PR TITLE
Add hook to tell the parent to trigger backdrop

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "cozy-search": "^0.6.0",
     "cozy-sharing": "^25.4.0",
     "cozy-tsconfig": "^1.8.1",
-    "cozy-ui": "^124.2.0",
+    "cozy-ui": "^125.0.0",
     "cozy-vcard": "^0.2.18",
     "final-form": "4.20.9",
     "final-form-arrays": "3.1.0",

--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Outlet } from 'react-router-dom'
+import { useIntentBackdrop } from 'src/components/Hooks/useIntentBackdrop'
 
 import { BarCenter } from 'cozy-bar'
 import { BarComponent } from 'cozy-bar'
@@ -17,6 +18,7 @@ import { ModalManager } from '../helpers/modalManager'
 const AppLayout = ({ withTopBar }) => {
   const client = useClient()
   const { isMobile } = useBreakpoints()
+  useIntentBackdrop()
 
   return (
     <Layout monoColumn withTopBar={withTopBar}>

--- a/src/components/ContactCard/ContactGroups/__snapshots__/ContactGroupList.spec.jsx.snap
+++ b/src/components/ContactCard/ContactGroups/__snapshots__/ContactGroupList.spec.jsx.snap
@@ -5,27 +5,31 @@ exports[`ContactGroupList should match the contact snapshot 1`] = `
   className="TwakeTheme--light-normal u-dc"
 >
   <div
-    className="u-mb-2"
+    className="styles__o-layout___3TSz9 styles__o-layout-2panes___1CDQw styles__o-layout-topbar___2SHWi"
   >
-    <h3
-      className="u-title-h2 u-mt-1-half u-mb-1"
+    <div
+      className="u-mb-2"
     >
-      Foo
-    </h3>
-    <ol
-      className="u-nolist u-m-0 u-p-0"
-    >
-      <li
-        className="u-dib u-slateGrey u-fz-small u-p-half u-mr-half u-w-auto u-maw-6 u-bg-paleGrey u-ellipsis"
+      <h3
+        className="u-title-h2 u-mt-1-half u-mb-1"
       >
-        The A Team
-      </li>
-      <li
-        className="u-dib u-slateGrey u-fz-small u-p-half u-mr-half u-w-auto u-maw-6 u-bg-paleGrey u-ellipsis"
+        Foo
+      </h3>
+      <ol
+        className="u-nolist u-m-0 u-p-0"
       >
-        The B Team
-      </li>
-    </ol>
+        <li
+          className="u-dib u-slateGrey u-fz-small u-p-half u-mr-half u-w-auto u-maw-6 u-bg-paleGrey u-ellipsis"
+        >
+          The A Team
+        </li>
+        <li
+          className="u-dib u-slateGrey u-fz-small u-p-half u-mr-half u-w-auto u-maw-6 u-bg-paleGrey u-ellipsis"
+        >
+          The B Team
+        </li>
+      </ol>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/ContactCard/__snapshots__/ContactAccounts.spec.jsx.snap
+++ b/src/components/ContactCard/__snapshots__/ContactAccounts.spec.jsx.snap
@@ -4,50 +4,54 @@ exports[`ContactAccounts component should render a list of contact accounts 1`] 
 <div
   className="TwakeTheme--light-normal u-dc"
 >
-  <h3
-    className="u-title-h2 u-mt-1-half u-mb-1"
+  <div
+    className="styles__o-layout___3TSz9 styles__o-layout-2panes___1CDQw styles__o-layout-topbar___2SHWi"
   >
-    Account linked to this contact
-  </h3>
-  <ol
-    className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
-  >
-    <li>
-      <div
-        className="u-flex u-mt-1 u-mb-half"
-      >
+    <h3
+      className="u-title-h2 u-mt-1-half u-mb-1"
+    >
+      Account linked to this contact
+    </h3>
+    <ol
+      className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
+    >
+      <li>
         <div
-          className="u-mr-1"
+          className="u-flex u-mt-1 u-mb-half"
         >
-          <svg
-            className="styles__icon___23x3R"
-            height="16"
-            style={Object {}}
-            width="16"
-          >
-            <use
-              xlinkHref="#google"
-            />
-          </svg>
-        </div>
-        <div>
           <div
-            className="u-mb-half u-breakword"
+            className="u-mr-1"
           >
-            <p
-              className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
+            <svg
+              className="styles__icon___23x3R"
+              height="16"
+              style={Object {}}
+              width="16"
             >
-              Google
-            </p>
-            <span
-              className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              <use
+                xlinkHref="#google"
+              />
+            </svg>
+          </div>
+          <div>
+            <div
+              className="u-mb-half u-breakword"
             >
-              john.doe@gmail.com
-            </span>
+              <p
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
+              >
+                Google
+              </p>
+              <span
+                className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                john.doe@gmail.com
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </li>
-  </ol>
+      </li>
+    </ol>
+  </div>
 </div>
 `;

--- a/src/components/ContactsList/__snapshots__/ContactListItem.spec.js.snap
+++ b/src/components/ContactsList/__snapshots__/ContactListItem.spec.js.snap
@@ -4,112 +4,116 @@ exports[`ContactListItem should match the contact snapshot 1`] = `
 <div
   className="TwakeTheme--light-normal u-dc"
 >
-  <li
-    className="MuiListItem-root u-c-pointer medium MuiListItem-gutters makeStyles-gutters-33 makeStyles-gutters-35"
-    data-testid="contact-listItem"
-    disabled={false}
-    onClick={[Function]}
-    size="medium"
+  <div
+    className="styles__o-layout___3TSz9 styles__o-layout-2panes___1CDQw styles__o-layout-topbar___2SHWi"
   >
-    <span
-      aria-disabled={false}
-      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-37 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary"
-      onBlur={[Function]}
+    <li
+      className="MuiListItem-root u-c-pointer medium MuiListItem-gutters makeStyles-gutters-33 makeStyles-gutters-35"
+      data-testid="contact-listItem"
+      disabled={false}
       onClick={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={null}
+      size="medium"
     >
       <span
-        className="MuiIconButton-label"
+        aria-disabled={false}
+        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-37 MuiCheckbox-root MuiCheckbox-colorPrimary MuiIconButton-colorPrimary"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={null}
       >
-        <input
-          aria-checked=""
-          aria-label=""
-          checked={false}
-          className="PrivateSwitchBase-input-40"
-          data-indeterminate={false}
-          onChange={[Function]}
-          readOnly={true}
-          type="checkbox"
-          value=""
-        />
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <span
+          className="MuiIconButton-label"
         >
-          <path
-            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+          <input
+            aria-checked=""
+            aria-label=""
+            checked={false}
+            className="PrivateSwitchBase-input-40"
+            data-indeterminate={false}
+            onChange={[Function]}
+            readOnly={true}
+            type="checkbox"
+            value=""
           />
-        </svg>
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+        </span>
       </span>
-    </span>
-    <div
-      className="styles__TableCell___3vgVE styles__contact-identity___mL3IJ u-flex u-flex-items-center u-ellipsis u-p-0"
-      data-testid="ContactIdentity"
-    >
       <div
-        className="styles__c-avatar___3jjlO styles__c-avatar--text___3Xssl"
-        data-testid="Avatar"
-        style={
-          Object {
-            "--circleSize": "24px",
-            "background": "linear-gradient(136deg, #6DCFFF 14.84%, #3D88F8 96.03%)",
+        className="styles__TableCell___3vgVE styles__contact-identity___mL3IJ u-flex u-flex-items-center u-ellipsis u-p-0"
+        data-testid="ContactIdentity"
+      >
+        <div
+          className="styles__c-avatar___3jjlO styles__c-avatar--text___3Xssl"
+          data-testid="Avatar"
+          style={
+            Object {
+              "--circleSize": "24px",
+              "background": "linear-gradient(136deg, #6DCFFF 14.84%, #3D88F8 96.03%)",
+            }
           }
-        }
-      >
-        <span
-          className="styles__c-avatar-initials___2dEdT"
         >
-          JD
-        </span>
+          <span
+            className="styles__c-avatar-initials___2dEdT"
+          >
+            JD
+          </span>
+        </div>
+        <p
+          className="MuiTypography-root u-ml-1 MuiTypography-body1 MuiTypography-colorTextPrimary MuiTypography-noWrap MuiTypography-gutterBottom MuiTypography-displayInline"
+          data-testid="ContactName"
+        >
+          <span
+            className=""
+          >
+            John
+             
+          </span>
+          <span
+            className="u-fw-bold"
+          >
+            Doe
+             
+          </span>
+        </p>
       </div>
-      <p
-        className="MuiTypography-root u-ml-1 MuiTypography-body1 MuiTypography-colorTextPrimary MuiTypography-noWrap MuiTypography-gutterBottom MuiTypography-displayInline"
-        data-testid="ContactName"
+      <div
+        className="styles__TableCell___3vgVE styles__contact-email___3n3q2 u-ellipsis u-p-0"
+        data-testid="ContactEmail"
       >
-        <span
-          className=""
-        >
-          John
-           
-        </span>
-        <span
-          className="u-fw-bold"
-        >
-          Doe
-           
-        </span>
-      </p>
-    </div>
-    <div
-      className="styles__TableCell___3vgVE styles__contact-email___3n3q2 u-ellipsis u-p-0"
-      data-testid="ContactEmail"
-    >
-      johndoe@localhost
-    </div>
-    <div
-      className="styles__TableCell___3vgVE styles__contact-phone___1sA_m u-ellipsis u-p-0"
-      data-testid="ContactPhone"
-    >
-      0123456789
-    </div>
-    <div
-      className="styles__TableCell___3vgVE styles__contact-cozyurl___3kBp5 u-ellipsis u-p-0"
-      data-testid="ContactCozy"
-    >
-      http://johndoe.mycozy.cloud
-    </div>
-  </li>
+        johndoe@localhost
+      </div>
+      <div
+        className="styles__TableCell___3vgVE styles__contact-phone___1sA_m u-ellipsis u-p-0"
+        data-testid="ContactPhone"
+      >
+        0123456789
+      </div>
+      <div
+        className="styles__TableCell___3vgVE styles__contact-cozyurl___3kBp5 u-ellipsis u-p-0"
+        data-testid="ContactCozy"
+      >
+        http://johndoe.mycozy.cloud
+      </div>
+    </li>
+  </div>
 </div>
 `;

--- a/src/components/Hooks/useIntentBackdrop.jsx
+++ b/src/components/Hooks/useIntentBackdrop.jsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+import { useMatch } from 'react-router-dom'
+
+export const useIntentBackdrop = () => {
+  const matchNew = useMatch('/new')
+  const matchImport = useMatch('/import')
+  const matchContact = useMatch('/:contactId')
+  const matchContactEdit = useMatch('/:contactId/edit')
+  const matchContactDelete = useMatch('/:contactId/delete')
+  const matchGroupDelete = useMatch('/group/:groupId/delete/:groupName')
+  const isMatching =
+    !!matchNew ||
+    !!matchImport ||
+    !!matchContact ||
+    !!matchContactEdit ||
+    !!matchContactDelete ||
+    !!matchGroupDelete
+
+  useEffect(() => {
+    if (isMatching) {
+      window.parent.postMessage('requestBackdropOpen', '*')
+    } else {
+      window.parent.postMessage('requestBackdropClose', '*')
+    }
+  }, [isMatching])
+}

--- a/src/components/Intents/IntentHandler.jsx
+++ b/src/components/Intents/IntentHandler.jsx
@@ -53,7 +53,7 @@ class IntentHandler extends Component {
 
     return (
       <div className="app-wrapper">
-        <main className="app-content">
+        <div className="app-content">
           {status === 'creating' && (
             <div className="intent-loader">
               <Spinner size="xxlarge" />
@@ -77,7 +77,7 @@ class IntentHandler extends Component {
               onError: error => service.throw(error),
               onTerminate: app => service.terminate(app)
             })}
-        </main>
+        </div>
       </div>
     )
   }

--- a/src/components/Modals/__snapshots__/ContactInfoContent.spec.jsx.snap
+++ b/src/components/Modals/__snapshots__/ContactInfoContent.spec.jsx.snap
@@ -4,208 +4,212 @@ exports[`ContactInfoContent should match snapshot when groups are available but 
 <div
   className="TwakeTheme--light-normal u-dc"
 >
-  <div>
-    <h3
-      className="u-title-h2 u-mt-1-half u-mb-1"
-    >
-      Contact informations
-    </h3>
-    <ol
-      className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
-    >
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
+  <div
+    className="styles__o-layout___3TSz9 styles__o-layout-2panes___1CDQw styles__o-layout-topbar___2SHWi"
+  >
+    <div>
+      <h3
+        className="u-title-h2 u-mt-1-half u-mb-1"
+      >
+        Contact informations
+      </h3>
+      <ol
+        className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
+      >
+        <li>
           <div
-            className="u-mr-1 u-fz-large"
+            className="u-flex u-mt-half"
           >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
                 }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#telephone"
-              />
-            </svg>
-          </div>
-          <div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              <a
-                className="u-link"
-                href="tel:+33 (1)9 14 02 28 31"
+                width="16"
               >
-                +33 (1)9 14 02 28 31
-              </a>
+                <use
+                  xlinkHref="#telephone"
+                />
+              </svg>
             </div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              <a
-                className="u-link"
-                href="tel:+33 (2)3 99 53 65 21"
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
               >
-                +33 (2)3 99 53 65 21
-              </a>
+                <a
+                  className="u-link"
+                  href="tel:+33 (1)9 14 02 28 31"
+                >
+                  +33 (1)9 14 02 28 31
+                </a>
+              </div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                <a
+                  className="u-link"
+                  href="tel:+33 (2)3 99 53 65 21"
+                >
+                  +33 (2)3 99 53 65 21
+                </a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
+        </li>
+        <li>
           <div
-            className="u-mr-1 u-fz-large"
+            className="u-flex u-mt-half"
           >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#email"
-              />
-            </svg>
-          </div>
-          <div>
             <div
-              className="u-mb-half u-breakword u-fz-medium"
+              className="u-mr-1 u-fz-large"
             >
-              <a
-                className="u-link"
-                href="mailto:rikki.white@celmax.name"
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
               >
-                rikki.white@celmax.name
-              </a>
+                <use
+                  xlinkHref="#email"
+                />
+              </svg>
             </div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              <a
-                className="u-link"
-                href="mailto:eleanore.fennell@thermolock.name"
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
               >
-                eleanore.fennell@thermolock.name
-              </a>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
-          <div
-            className="u-mr-1 u-fz-large"
-          >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#location"
-              />
-            </svg>
-          </div>
-          <div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              <a
-                className="u-link"
-                href="https://nominatim.openstreetmap.org/search?format=html&q=48%20Fuller%20Road,%2006635%20Stafford,%20Solomon%20Islands"
-                rel="noopener noreferrer"
-                target="_blank"
+                <a
+                  className="u-link"
+                  href="mailto:rikki.white@celmax.name"
+                >
+                  rikki.white@celmax.name
+                </a>
+              </div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
               >
-                48 Fuller Road, 06635 Stafford, Solomon Islands
-              </a>
+                <a
+                  className="u-link"
+                  href="mailto:eleanore.fennell@thermolock.name"
+                >
+                  eleanore.fennell@thermolock.name
+                </a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
+        </li>
+        <li>
           <div
-            className="u-mr-1 u-fz-large"
+            className="u-flex u-mt-half"
           >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#calendar"
-              />
-            </svg>
-          </div>
-          <div>
             <div
-              className="u-mb-half u-breakword u-fz-medium"
+              className="u-mr-1 u-fz-large"
             >
-              1998-06-03
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#location"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                <a
+                  className="u-link"
+                  href="https://nominatim.openstreetmap.org/search?format=html&q=48%20Fuller%20Road,%2006635%20Stafford,%20Solomon%20Islands"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  48 Fuller Road, 06635 Stafford, Solomon Islands
+                </a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
+        </li>
+        <li>
           <div
-            className="u-mr-1 u-fz-large"
+            className="u-flex u-mt-half"
           >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#flag"
-              />
-            </svg>
-          </div>
-          <div>
             <div
-              className="u-mb-half u-breakword u-fz-medium"
+              className="u-mr-1 u-fz-large"
             >
-              unsupportedField
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#calendar"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                1998-06-03
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-    </ol>
+        </li>
+        <li>
+          <div
+            className="u-flex u-mt-half"
+          >
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#flag"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                unsupportedField
+              </div>
+            </div>
+          </div>
+        </li>
+      </ol>
+    </div>
   </div>
 </div>
 `;
@@ -215,177 +219,181 @@ exports[`ContactInfoContent should match snapshot with accounts and groups 1`] =
   className="TwakeTheme--light-normal u-dc"
 >
   <div
-    className="u-mb-2"
+    className="styles__o-layout___3TSz9 styles__o-layout-2panes___1CDQw styles__o-layout-topbar___2SHWi"
   >
-    <h3
-      className="u-title-h2 u-mt-1-half u-mb-1"
+    <div
+      className="u-mb-2"
     >
-      Groups
-    </h3>
-    <ol
-      className="u-nolist u-m-0 u-p-0"
-    >
-      <li
-        className="u-dib u-slateGrey u-fz-small u-p-half u-mr-half u-w-auto u-maw-6 u-bg-paleGrey u-ellipsis"
+      <h3
+        className="u-title-h2 u-mt-1-half u-mb-1"
       >
-        toto
-      </li>
-    </ol>
-  </div>
-  <div>
+        Groups
+      </h3>
+      <ol
+        className="u-nolist u-m-0 u-p-0"
+      >
+        <li
+          className="u-dib u-slateGrey u-fz-small u-p-half u-mr-half u-w-auto u-maw-6 u-bg-paleGrey u-ellipsis"
+        >
+          toto
+        </li>
+      </ol>
+    </div>
+    <div>
+      <h3
+        className="u-title-h2 u-mt-1-half u-mb-1"
+      >
+        Contact informations
+      </h3>
+      <ol
+        className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
+      >
+        <li>
+          <div
+            className="u-flex u-mt-half"
+          >
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#email"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                <a
+                  className="u-link"
+                  href="mailto:rikki.white@celmax.name"
+                >
+                  rikki.white@celmax.name
+                </a>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div
+            className="u-flex u-mt-half"
+          >
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#calendar"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                1998-06-03
+              </div>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div
+            className="u-flex u-mt-half"
+          >
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#flag"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                unsupportedField
+              </div>
+            </div>
+          </div>
+        </li>
+      </ol>
+    </div>
     <h3
       className="u-title-h2 u-mt-1-half u-mb-1"
     >
-      Contact informations
+      Account linked to this contact
     </h3>
     <ol
       className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
     >
       <li>
         <div
-          className="u-flex u-mt-half"
+          className="u-flex u-mt-1 u-mb-half"
         >
           <div
-            className="u-mr-1 u-fz-large"
+            className="u-mr-1"
           >
             <svg
               className="styles__icon___23x3R"
               height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
+              style={Object {}}
               width="16"
             >
               <use
-                xlinkHref="#email"
+                xlinkHref="#google"
               />
             </svg>
           </div>
           <div>
             <div
-              className="u-mb-half u-breakword u-fz-medium"
+              className="u-mb-half u-breakword"
             >
-              <a
-                className="u-link"
-                href="mailto:rikki.white@celmax.name"
+              <p
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
               >
-                rikki.white@celmax.name
-              </a>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
-          <div
-            className="u-mr-1 u-fz-large"
-          >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#calendar"
-              />
-            </svg>
-          </div>
-          <div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              1998-06-03
-            </div>
-          </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
-          <div
-            className="u-mr-1 u-fz-large"
-          >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#flag"
-              />
-            </svg>
-          </div>
-          <div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              unsupportedField
+                Google
+              </p>
+              <span
+                className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                john.doe@gmail.com
+              </span>
             </div>
           </div>
         </div>
       </li>
     </ol>
   </div>
-  <h3
-    className="u-title-h2 u-mt-1-half u-mb-1"
-  >
-    Account linked to this contact
-  </h3>
-  <ol
-    className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
-  >
-    <li>
-      <div
-        className="u-flex u-mt-1 u-mb-half"
-      >
-        <div
-          className="u-mr-1"
-        >
-          <svg
-            className="styles__icon___23x3R"
-            height="16"
-            style={Object {}}
-            width="16"
-          >
-            <use
-              xlinkHref="#google"
-            />
-          </svg>
-        </div>
-        <div>
-          <div
-            className="u-mb-half u-breakword"
-          >
-            <p
-              className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
-            >
-              Google
-            </p>
-            <span
-              className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-            >
-              john.doe@gmail.com
-            </span>
-          </div>
-        </div>
-      </div>
-    </li>
-  </ol>
 </div>
 `;
 
@@ -393,159 +401,163 @@ exports[`ContactInfoContent should match snapshot with accounts without groups 1
 <div
   className="TwakeTheme--light-normal u-dc"
 >
-  <div>
+  <div
+    className="styles__o-layout___3TSz9 styles__o-layout-2panes___1CDQw styles__o-layout-topbar___2SHWi"
+  >
+    <div>
+      <h3
+        className="u-title-h2 u-mt-1-half u-mb-1"
+      >
+        Contact informations
+      </h3>
+      <ol
+        className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
+      >
+        <li>
+          <div
+            className="u-flex u-mt-half"
+          >
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#email"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                <a
+                  className="u-link"
+                  href="mailto:rikki.white@celmax.name"
+                >
+                  rikki.white@celmax.name
+                </a>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div
+            className="u-flex u-mt-half"
+          >
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#calendar"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                1998-06-03
+              </div>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div
+            className="u-flex u-mt-half"
+          >
+            <div
+              className="u-mr-1 u-fz-large"
+            >
+              <svg
+                className="styles__icon___23x3R"
+                height="16"
+                style={
+                  Object {
+                    "fill": "var(--iconTextColor)",
+                  }
+                }
+                width="16"
+              >
+                <use
+                  xlinkHref="#flag"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                className="u-mb-half u-breakword u-fz-medium"
+              >
+                unsupportedField
+              </div>
+            </div>
+          </div>
+        </li>
+      </ol>
+    </div>
     <h3
       className="u-title-h2 u-mt-1-half u-mb-1"
     >
-      Contact informations
+      Account linked to this contact
     </h3>
     <ol
       className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
     >
       <li>
         <div
-          className="u-flex u-mt-half"
+          className="u-flex u-mt-1 u-mb-half"
         >
           <div
-            className="u-mr-1 u-fz-large"
+            className="u-mr-1"
           >
             <svg
               className="styles__icon___23x3R"
               height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
+              style={Object {}}
               width="16"
             >
               <use
-                xlinkHref="#email"
+                xlinkHref="#google"
               />
             </svg>
           </div>
           <div>
             <div
-              className="u-mb-half u-breakword u-fz-medium"
+              className="u-mb-half u-breakword"
             >
-              <a
-                className="u-link"
-                href="mailto:rikki.white@celmax.name"
+              <p
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
               >
-                rikki.white@celmax.name
-              </a>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
-          <div
-            className="u-mr-1 u-fz-large"
-          >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#calendar"
-              />
-            </svg>
-          </div>
-          <div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              1998-06-03
-            </div>
-          </div>
-        </div>
-      </li>
-      <li>
-        <div
-          className="u-flex u-mt-half"
-        >
-          <div
-            className="u-mr-1 u-fz-large"
-          >
-            <svg
-              className="styles__icon___23x3R"
-              height="16"
-              style={
-                Object {
-                  "fill": "var(--iconTextColor)",
-                }
-              }
-              width="16"
-            >
-              <use
-                xlinkHref="#flag"
-              />
-            </svg>
-          </div>
-          <div>
-            <div
-              className="u-mb-half u-breakword u-fz-medium"
-            >
-              unsupportedField
+                Google
+              </p>
+              <span
+                className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                john.doe@gmail.com
+              </span>
             </div>
           </div>
         </div>
       </li>
     </ol>
   </div>
-  <h3
-    className="u-title-h2 u-mt-1-half u-mb-1"
-  >
-    Account linked to this contact
-  </h3>
-  <ol
-    className="u-nolist u-m-0 u-p-0 u-pl-1-half u-pl-0-s"
-  >
-    <li>
-      <div
-        className="u-flex u-mt-1 u-mb-half"
-      >
-        <div
-          className="u-mr-1"
-        >
-          <svg
-            className="styles__icon___23x3R"
-            height="16"
-            style={Object {}}
-            width="16"
-          >
-            <use
-              xlinkHref="#google"
-            />
-          </svg>
-        </div>
-        <div>
-          <div
-            className="u-mb-half u-breakword"
-          >
-            <p
-              className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
-            >
-              Google
-            </p>
-            <span
-              className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-            >
-              john.doe@gmail.com
-            </span>
-          </div>
-        </div>
-      </div>
-    </li>
-  </ol>
 </div>
 `;

--- a/src/styles/intent.styl
+++ b/src/styles/intent.styl
@@ -30,9 +30,11 @@
         flex 1
 
 .intent-main
+    display flex
     flex 1
     overflow-y auto
     width 100%
+    background-color var(--paperBackgroundColor)
 
 .intent-create-form-wrapper
     padding 1rem 2rem

--- a/src/tests/Applike.jsx
+++ b/src/tests/Applike.jsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import { HashRouter } from 'react-router-dom'
 
 import { CozyProvider } from 'cozy-client'
+import { Layout } from 'cozy-ui/transpiled/react/Layout'
 import AlertProvider from 'cozy-ui/transpiled/react/providers/Alert'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import CozyTheme from 'cozy-ui/transpiled/react/providers/CozyTheme'
@@ -27,7 +28,9 @@ const AppLike = ({ children, client }) => (
               <ContactsDiplayedProvider>
                 <SelectedGroupProvider>
                   <SearchProvider>
-                    <HashRouter>{children}</HashRouter>
+                    <HashRouter>
+                      <Layout>{children}</Layout>
+                    </HashRouter>
                   </SearchProvider>
                 </SelectedGroupProvider>
               </ContactsDiplayedProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5471,10 +5471,10 @@ cozy-tsconfig@^1.8.1:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.8.1.tgz#5f206f4e6e041a4afc6691098264ba630bdeb7e2"
   integrity sha512-/9QBxK8Tc12O2ojuyRpSMjPpXpqldVvzfNB1+/nPD+IkIBkU+mqxpHYJwKWjNYHGraCSy69mIwt9J3aiaJdz9w==
 
-cozy-ui@^124.2.0:
-  version "124.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-124.2.0.tgz#87956859f1d8aa31cd3aaffb96b67cddea7fb4b9"
-  integrity sha512-T0Jj0Jx7bTqwRU2AHNzPhGntu+/0hFUid0lIIjHaCOVZIKWBOrg18TQLc+k5IdFZRctSHfFgeolkp3U38ArDJw==
+cozy-ui@^125.0.0:
+  version "125.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-125.0.0.tgz#adfd6f9fdc54db216e225094f9170501b1d9813e"
+  integrity sha512-iLNIBxBi534xf3QmIw3dOLTNVM8jjayzDvkrI7GUMyUnmD/P3Ji/7bYUuessO/cOJN+csQq+7OGogW8g+WjOSw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"


### PR DESCRIPTION
the entire app can be used in an iframe, as in cozy-admin for example. In this case, when a modal opens, there's a backdrop behind it, but it's constrained to the iframe. To extend this backdrop to the entire app, the iframe sends a `requestBackdropOpen` command received by the parent, triggering the opening of a global backdrop.

relative to https://github.com/cozy/cozy-admin/pull/8