### PR TITLE
fix(ContactFieldInput): Add min-width to avoid text and border overlap

### DIFF
--- a/src/components/ContactCard/ContactFieldInput.jsx
+++ b/src/components/ContactCard/ContactFieldInput.jsx
@@ -75,7 +75,7 @@ const ContactFieldInput = ({
       )}
       {labelProps && (
         <HasValueCondition name={name} otherCondition={hasBeenFocused}>
-          <div className="u-mt-half-s u-ml-half u-ml-0-s u-flex-shrink-0 u-w-auto">
+          <div className="u-mt-half-s u-ml-half u-ml-0-s u-flex-shrink-0 u-w-auto u-miw-4">
             <Field
               attributes={labelProps}
               name={`${name}Label`}


### PR DESCRIPTION
in contact edit modal.

before: 
<img width="89" height="75" alt="image" src="https://github.com/user-attachments/assets/9f45f9ed-4215-4e00-b8f2-38e20ffcb94e" />

after: 
<img width="145" height="71" alt="image" src="https://github.com/user-attachments/assets/81b17275-f95b-448f-a7bc-e480f26c6d52" />
